### PR TITLE
fix: Adjust phases for rules setting TX variables

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -28,7 +28,7 @@ SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,
 #
 # SecRule REQUEST_FILENAME "@rx /(?:remote.php|index.php)/" \
 #   "id:9508600,\
-#   phase:1,\
+#   phase:2,\
 #   t:none,\
 #   nolog,\
 #   pass,\
@@ -100,7 +100,7 @@ SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
 # Allow the data type 'text/vcard'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9508110,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -110,7 +110,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
 # Allow the data type 'application/octet-stream'
 SecRule REQUEST_METHOD "@pm PUT MOVE" \
     "id:9508115,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -194,7 +194,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
 #   CHECKOUT COPY LOCK MERGE MKACTIVITY UNLOCK.
 SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     "id:9508130,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -206,7 +206,7 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
 # PUT - when setting a password / expiration time
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     "id:9508140,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -290,7 +290,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
 # Allow the data type 'text/vcard'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \
     "id:9508320,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -318,7 +318,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
 # Allow the data type 'text/calendar'
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
     "id:9508330,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -449,7 +449,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
 # Fixes deletion of auth tokens
 SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
     "id:9508601,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -461,7 +461,7 @@ SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
 # Fixed "Security & setup warnings" test
 SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
     "id:9508602,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -470,7 +470,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
 
 SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
     "id:9508603,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -486,7 +486,7 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
 # Allows notifications to be deleted
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/notifications/api/v2/notifications" \
     "id:9508701,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\
@@ -519,7 +519,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/api/v1/shares
 # Allow users to be deleted
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/cloud/users/" \
     "id:9508850,\
-    phase:1,\
+    phase:2,\
     pass,\
     t:none,\
     nolog,\


### PR DESCRIPTION
TX variables in phase 1 are overwritten by the CRS initialization. Moving them to phase 2 does *not* fix the issue but is in line with the how the rules were executed before they were moved into the plugin.

Relates to #2