### PR TITLE
decrease the 'phase' values

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -194,7 +194,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
 #   CHECKOUT COPY LOCK MERGE MKACTIVITY UNLOCK.
 SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     "id:9508130,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\
@@ -206,7 +206,7 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
 # PUT - when setting a password / expiration time
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/files_sharing/" \
     "id:9508140,\
-    phase:2,\
+    phase:1,\
     pass,\
     t:none,\
     nolog,\


### PR DESCRIPTION
In [this commit](https://github.com/coreruleset/coreruleset/commit/5a47465f9cee33d46ac62b03fd300195bbee8c2f) made three years ago, the 'phase' values for some rules were reduced, including the rule [911100](https://github.com/coreruleset/coreruleset/commit/5a47465f9cee33d46ac62b03fd300195bbee8c2f#diff-74c2e602499bf7b7a23dbbe1bbb2ba1251c466e60ab3c3684210bb2aef042773) which is responsible for handling request methods. The NextCloud DAV functionality doesn't work with the previous values.