### PR TITLE
feat: Copy of tx.allowed_request_content_type initialization

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,5 +13,6 @@
 - [pyllyukko](https://github.com/pyllyukko)
 - [Chaim Sanders](https://github.com/csanders-git)
 - [Federico G. Schwindt](https://github.com/fgsch)
+- [Jozef Sudolský](https://github.com/azurit)
 - [Timo](https://github.com/ntimo)
 - [Felipe Zipitría](https://github.com/fzipi)

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -50,7 +50,7 @@ SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,
 
 # Copy of default HTTP policy: allowed_request_content_type (rule 900220 in crs-setup.conf)
 # We need to initialize this also here because plugin setup runs before CRS initialization (this
-# is a know limitation of current plugin implementation). Must be kept in sync with CRS
+# is a known limitation of the current plugin architecture). Must be kept in sync with CRS
 # default setting.
 SecRule &TX:allowed_request_content_type "@eq 0" \
     "id:9508100,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -48,13 +48,26 @@ SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,
 # in libmodsecurity3!
 
 
+# Copy of default HTTP policy: allowed_request_content_type (rule 900220 in crs-setup.conf)
+# We need to initialize this also here because plugins runs before CRS initialization (this
+# is a know limitation of current plugin implementation). Must be kept in sync with CRS
+# default setting.
+SecRule &TX:allowed_request_content_type "@eq 0" \
+    "id:9508100,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_request_content_type=|application/x-www-form-urlencoded| |multipart/form-data| |multipart/related| |text/xml| |application/xml| |application/soap+xml| |application/json| |application/cloudevents+json| |application/cloudevents-batch+json|'"
+
+
 #
 # [ File Manager ]
 #
 
 # The web interface uploads files, and interacts with the user.
 SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
-    "id:9508100,\
+    "id:9508101,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -48,12 +48,27 @@ SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,
 # in libmodsecurity3!
 
 
-# Copy of default HTTP policy: allowed_request_content_type (rule 900220 in crs-setup.conf)
-# We need to initialize this also here because plugin setup runs before CRS initialization (this
-# is a known limitation of the current plugin architecture). Must be kept in sync with CRS
-# default setting.
-SecRule &TX:allowed_request_content_type "@eq 0" \
+#
+# [ CRS initialization ]
+#
+# We need to initialize some of the CRS variables also here because plugin setup runs before
+# CRS initialization (this is a known limitation of the current plugin architecture). Must be
+# kept in sync with CRS default setting.
+
+
+# Copy or CRS rule 901160.
+SecRule &TX:allowed_methods "@eq 0" \
     "id:9508100,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
+
+
+# Copy or CRS rule 901162.
+SecRule &TX:allowed_request_content_type "@eq 0" \
+    "id:9508101,\
     phase:1,\
     pass,\
     nolog,\
@@ -67,7 +82,7 @@ SecRule &TX:allowed_request_content_type "@eq 0" \
 
 # The web interface uploads files, and interacts with the user.
 SecRule REQUEST_FILENAME "@contains /remote.php/webdav" \
-    "id:9508101,\
+    "id:9508102,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -49,14 +49,14 @@ SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,
 
 
 #
-# [ CRS initialization ]
+# [ Local CRS initialization ]
 #
 # We need to initialize some of the CRS variables also here because plugin setup runs before
 # CRS initialization (this is a known limitation of the current plugin architecture). Must be
 # kept in sync with CRS default setting.
 
 
-# Copy or CRS rule 901160.
+# Copy of CRS rule 901160.
 SecRule &TX:allowed_methods "@eq 0" \
     "id:9508100,\
     phase:1,\
@@ -66,7 +66,7 @@ SecRule &TX:allowed_methods "@eq 0" \
     setvar:'tx.allowed_methods=GET HEAD POST OPTIONS'"
 
 
-# Copy or CRS rule 901162.
+# Copy of CRS rule 901162.
 SecRule &TX:allowed_request_content_type "@eq 0" \
     "id:9508101,\
     phase:1,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -49,7 +49,7 @@ SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,
 
 
 # Copy of default HTTP policy: allowed_request_content_type (rule 900220 in crs-setup.conf)
-# We need to initialize this also here because plugins runs before CRS initialization (this
+# We need to initialize this also here because plugin setup runs before CRS initialization (this
 # is a know limitation of current plugin implementation). Must be kept in sync with CRS
 # default setting.
 SecRule &TX:allowed_request_content_type "@eq 0" \


### PR DESCRIPTION
As discussed on Slack, this is needed for proper modification of `tx.allowed_request_content_type` by exclusion rules. Plugins are currently running before CRS initialization so variables like `tx.allowed_request_content_type` needs to be initialized also by plugins if they are going to be modified.