### PR TITLE
Fix FP when logging in, Nextcloud Text app and when adding custom CSS code

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -230,7 +230,7 @@ SecRule REQUEST_URI "@contains /apps/text/session/sync" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:autosaveContent"
 
 # Text app content can be anything
-SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/sync"
+SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/sync" \
    "id:9508127,\
     phase:1,\
     pass,\
@@ -240,7 +240,7 @@ SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/sync"
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.autosaveContent"
 
 # Text app content can be anything
-SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/push"
+SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/push" \
    "id:9508128,\
     phase:1,\
     t:none,\
@@ -250,7 +250,7 @@ SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/push"
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS"
 
 # Text app content can be anything
-SecRule REQUEST_FILENAME "@endsWith /apps/text/session/push"
+SecRule REQUEST_FILENAME "@endsWith /apps/text/session/push" \
    "id:9508129,\
     phase:1,\
     pass,\
@@ -868,7 +868,7 @@ SecRule REQUEST_FILENAME "@contains /apps/notes/notes/" \
 #
 
 # Allow admin to add custom CSS code
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/provisioning_api/api/v[0-9]/config/apps/theming_customcss/customcss$"
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/provisioning_api/api/v[0-9]/config/apps/theming_customcss/customcss$" \
    "id:9508930,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -863,4 +863,18 @@ SecRule REQUEST_FILENAME "@contains /apps/notes/notes/" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.title,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
+#
+# [ Custom CSS ]
+#
+
+# Allow admin to add CSS custom CSS code
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/provisioning_api/api/v[0-9]/config/apps/theming_customcss/customcss$"
+   "id:9508930,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value"    
+   
 SecMarker "END-NEXTCLOUD-ADMIN"

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -457,7 +457,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
 # This removes checks on the 'password' and related fields:
 
 # User login password.
-SecRule REQUEST_FILENAME "@contains /index.php/login" \
+SecRule REQUEST_FILENAME "@contains /login" \
     "id:9508400,\
     phase:1,\
     pass,\
@@ -468,7 +468,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/login" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0'"
 
 # Reset password.
-SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
+SecRule REQUEST_FILENAME "@endsWith /login" \
     "id:9508410,\
     phase:2,\
     pass,\
@@ -486,7 +486,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/login" \
             ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
 
 # Logout token
-SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
+SecRule REQUEST_FILENAME "@endsWith /logout" \
     "id:9508420,\
     phase:1,\
     pass,\
@@ -496,7 +496,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/logout" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0'"
 
 # Change Password and Setting up a new user/password
-SecRule REQUEST_FILENAME "@endsWith /index.php/settings/users" \
+SecRule REQUEST_FILENAME "@endsWith /settings/users" \
     "id:9508500,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -228,7 +228,37 @@ SecRule REQUEST_URI "@contains /apps/text/session/sync" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:autosaveContent"
-        
+
+# Text app content can be anything
+SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/sync"
+   "id:9508127,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.autosaveContent"
+
+# Text app content can be anything
+SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/push"
+   "id:9508128,\
+    phase:1,\
+    t:none,\
+    pass,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS"
+
+# Text app content can be anything
+SecRule REQUEST_FILENAME "@endsWith /apps/text/session/push"
+   "id:9508129,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS"
+   
 #
 # [ Searchengine ]
 #

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -487,7 +487,7 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
 # This removes checks on the 'password' and related fields:
 
 # User login password.
-SecRule REQUEST_FILENAME "@contains /login" \
+SecRule REQUEST_FILENAME "@endsWith /login" \
     "id:9508400,\
     phase:1,\
     pass,\
@@ -867,7 +867,7 @@ SecRule REQUEST_FILENAME "@contains /apps/notes/notes/" \
 # [ Custom CSS ]
 #
 
-# Allow admin to add CSS custom CSS code
+# Allow admin to add custom CSS code
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/provisioning_api/api/v[0-9]/config/apps/theming_customcss/customcss$"
    "id:9508930,\
     phase:1,\


### PR DESCRIPTION
This PR fixes a few false positives
1. Rules for fixing false positives when logging in, changing passwords, logging out etc assume the Nextcloud instance is not using [pretty URLs](https://docs.nextcloud.com/server/latest/admin_manual/installation/source_installation.html#pretty-urls). I've removed  ``/index.php`` which should work for Nextcloud instances that both are and aren't using [pretty URLs](https://docs.nextcloud.com/server/latest/admin_manual/installation/source_installation.html#pretty-urls).
2. Fix few additional false positives with Nextcloud Text app including when accessing Nextcloud Text app via a public share.
3. Fix false positives with adding custom CSS code via Nextcloud Custom CSS app.

I've done ``ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS"`` for 9508128 and 9508129 since the parameter keeps on changing, it can vary from ``ARGS:json.steps.array_0.slice.content.array_0.content.array_0.text`` to ``ARGS:json.steps.array_100.slice.content.array_0.content.array_0.text``.