### PR TITLE
Extended text app auto sync. Notes app able to save to its settings.

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -457,19 +457,8 @@ SecRule REQUEST_METHOD "@streq PROPFIND" \
 
 # We want to allow a lot of things as the user is
 # allowed to note on anything.
-SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
+SecRule REQUEST_FILENAME "@rx ^(?:/index.php)?/apps/notes/" \
     "id:9508340,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ctl:ruleRemoveByTag=attack-injection-php,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# Allow Notes App to save to its settings
-SecRule REQUEST_FILENAME "@contains /apps/notes/settings" \
-    "id:9508341,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -219,7 +219,7 @@ SecRule REQUEST_FILENAME "@contains /apps/recommendations/settings/enabled" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 
-# Text app autosave sync feature doesn't works 
+# Text app autosave sync feature doesn't work 
 SecRule REQUEST_URI "@contains /apps/text/session/sync" \
     "id:9508126,\
     phase:1,\
@@ -227,7 +227,7 @@ SecRule REQUEST_URI "@contains /apps/text/session/sync" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:autosaveContent"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS"
 
 # Text app content can be anything
 SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/sync" \
@@ -463,8 +463,19 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
     t:none,\
     nolog,\
     ctl:ruleRemoveByTag=attack-injection-php,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0'"
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 
+# Allow Notes App to save to its settings
+SecRule REQUEST_FILENAME "@contains /apps/notes/settings" \
+    "id:9508341,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveByTag=attack-injection-php,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 
 #
 # [ Bookmarks ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -402,6 +402,7 @@ SecRule REQUEST_METHOD "@streq PUT" \
     pass,\
     t:none,\
     nolog,\
+    ctl:ruleRemoveById=920450,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
     SecRule REQUEST_FILENAME "@contains /remote.php/dav/addressbooks/" \

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -227,7 +227,7 @@ SecRule REQUEST_URI "@contains /apps/text/session/sync" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:autosaveContent"
 
 # Text app content can be anything
 SecRule REQUEST_FILENAME "@endsWith /apps/text/public/session/sync" \


### PR DESCRIPTION
Hey Everyone,
I am pretty new to github and even less experienced with coreruleset, so any advice for improvements is very much welcome!

**Versions**
- Nextcloud 27.0.0.8
- Nginx 1.24.0 build with ModSecurity 3.0.8
- OWASP_CRS/4.0.0-rc1

**Changes**
Added a new rule ```9508341``` to allow the notes app to save to its own settings.

Extended existing rule ```9508126``` to allow get autosaving of text app working again (update of Nextcloud broke functionality).

I would really appreciate some feedback because I have no idea if this is a decent approach or totally bollocks - it works though but it doesn't mean it can't be done better. Iam fascinated by your project but is not easy for me to wrap my head around. So any tips I would appreciate very much!

