### PR TITLE
Address FP in NC 27 file manager - details - versioning and system tags

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -135,6 +135,39 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain| |text/vcard|'"
 
+# File manager: versioning
+# Allow the data type 'text/plain'
+SecRule REQUEST_FILENAME "@contains /remote.php/dav/versions/" \
+    "id:9508111,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
+
+# File manager: system tags
+# Allow the data type 'text/plain'
+SecRule REQUEST_FILENAME "@contains /remote.php/dav/systemtags/" \
+    "id:9508112,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'" 
+
+# File manager: system tags
+# Allow the data type 'text/plain'
+SecRule REQUEST_FILENAME "@contains /remote.php/dav/systemtags-relations/" \
+    "id:9508113,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'" 
+
 # Allow the data type 'application/octet-stream'
 SecRule REQUEST_METHOD "@pm PUT MOVE" \
     "id:9508115,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -137,36 +137,29 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
 
 # File manager: versioning
 # Allow the data type 'text/plain'
+# Since the content is actually XML, we switch on the XML parser
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/versions/" \
     "id:9508111,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    ctl:requestBodyProcessor=XML,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
 # File manager: system tags
 # Allow the data type 'text/plain'
-SecRule REQUEST_FILENAME "@contains /remote.php/dav/systemtags/" \
+# Since the content is actually XML, we switch on the XML parser
+SecRule REQUEST_FILENAME "@rx /remote.php/dav/systemtags(?:-relations)/" \
     "id:9508112,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
+    ctl:requestBodyProcessor=XML,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'" 
-
-# File manager: system tags
-# Allow the data type 'text/plain'
-SecRule REQUEST_FILENAME "@contains /remote.php/dav/systemtags-relations/" \
-    "id:9508113,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'" 
+    setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
 # Allow the data type 'application/octet-stream'
 SecRule REQUEST_METHOD "@pm PUT MOVE" \

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -138,7 +138,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
 # File manager: versioning
 # Allow the data type 'text/plain'
 # Since the content is actually XML, we switch on the XML parser
-SecRule REQUEST_FILENAME "@contains /remote.php/dav/versions/" \
+SecRule REQUEST_FILENAME "@beginsWith /remote.php/dav/versions/" \
     "id:9508111,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -151,7 +151,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/versions/" \
 # File manager: system tags
 # Allow the data type 'text/plain'
 # Since the content is actually XML, we switch on the XML parser
-SecRule REQUEST_FILENAME "@rx /remote.php/dav/systemtags(?:-relations)/" \
+SecRule REQUEST_FILENAME "@rx /remote.php/dav/systemtags(?:-relations)?/" \
     "id:9508112,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -151,7 +151,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/versions/" \
 # File manager: system tags
 # Allow the data type 'text/plain'
 # Since the content is actually XML, we switch on the XML parser
-SecRule REQUEST_FILENAME "@rx /remote.php/dav/systemtags(?:-relations)?/" \
+SecRule REQUEST_FILENAME "@rx ^/remote.php/dav/systemtags(?:-relations)?/" \
     "id:9508112,\
     phase:1,\
     pass,\


### PR DESCRIPTION
**Versions**
- Nextcloud 27.0.0.8
- Nginx 1.24.0 build with ModSecurity 3.0.8
- OWASP_CRS/4.0.0-nightly (updated)

**Issue**
Accessing file details in the file manager throws FPs for the following URLs:

     /remote.php/dav/systemtags-relations/files/
     /remote.php/dav/systemtags/
     /remote.php/dav/versions/_USERNAME_/versions/

**Reason**

    TX:content_type' (Value: `|text/plain|`

is not allowed.

I can provide detailed logs if needed.
Thanks for your consideration.
