### PR TITLE
URL content triggers FP from rule 933120 when syncing

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -508,13 +508,14 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
 #
 
 # Allow urls in data.
-SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
+SecRule REQUEST_FILENAME "@beginsWith /index.php/apps/bookmarks/" \
     "id:9508350,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveById=933120,\
     ctl:ruleRemoveById=931130"
 
 


### PR DESCRIPTION
**Versions**

    FreeBSD 13.2-RELEASE-p2
    nginx version: nginx/1.24.0 
    CRS v4.0/dev 
    Floccus Extension 4.19.1 (Firefox Browser)
    
**Issue**

Certain URLs trigger a FP when the content matches `./rules/php-config-directives.data`.
In this particular case, *engine* is matched.
The affected URL is https://engineer.kodekloud.com/?utm_source=Linkedin&utm_medium=social&utm_campaign=Introducing+KKE+2.0+-+Mumshad+Video&utm_content=video

    "request": {
      "method": "PUT",
      "http_version": 2,
      "uri": "/index.php/apps/bookmarks/public/rest/v2/bookmark/767",
      "headers": {
        "sec-fetch-mode": "cors",
        "sec-fetch-dest": "empty",
        "authorization": "Basic ***",
        "host": "cloud.gion.io",
        "sec-fetch-site": "same-origin",
        "user-agent": "Mozilla/5.0 (X11; Linux x86_64; rv:109.0) Gecko/20100101 Firefox/115.0",
        "accept": "*/*",
        "content-length": "238",
        "te": "trailers",
        "accept-language": "de,en-US;q=0.7,en;q=0.3",
        "accept-encoding": "gzip, deflate, br",
        "content-type": "application/json",
        "origin": "moz-extension://67ef67e2-7fb3-4831-b211-332cbd2d6c36"
      }

    --- snip ---

    "producer": {
          "modsecurity": "ModSecurity v3.0.8 (FreeBSD)",
          "connector": "ModSecurity-nginx v1.0.3",
          "secrules_engine": "Enabled",
          "components": [
            "OWASP_CRS/4.0.0-rc1\""
          ]
        },
        "messages": [
          {
            "message": "PHP Injection Attack: Configuration Directive Found",
            "details": {
              "match": "Matched \"Operator `Pm' with parameter `=' against variable `MATCHED_VARS:ARGS:json.url' (Value: `https:/engineer.kodekloud.com/?utm_source=Linkedin&utm_medium=social&utm_campaign=Introducing+KKE+2. (35 characters omitted)' )",
              "reference": "o7,6v9,136t:normalisePatho10,6v11,56t:normalisePatho41,1v584,135",
              "ruleId": "933120",
              "file": "/usr/local/etc/modsecurity/owasp-modsecurity-crs/rules/REQUEST-933-APPLICATION-ATTACK-PHP.conf",
              "lineNumber": "112",
              "data": "Matched Data: engine found within MATCHED_VARS:ARGS:json.url: https:/engineer.kodekloud.com/?utm_source=Linkedin&utm_medium=social&utm_campaign=Introducing+KKE+2.0+-+Mumshad+Video&utm_content=video",
              "severity": "2",
              "ver": "OWASP_CRS/4.0.0-rc1",
              "rev": "",
              "tags": [
                "application-multi",
                "language-php",
                "platform-multi",
                "attack-injection-php",
                "paranoia-level/1",
                "OWASP_CRS",
                "capec/1000/152/242"
              ],
              "maturity": "0",
              "accuracy": "0"
            }
          },

**Solution**

I suggest we disable rule `933120` because URLs may include any of the keywords in `php-config-directives.data`.
Also made the exclusion little bit more strict by changing `@contains` to `@beginsWith` in the REQUEST_FILENAME.

If there is a more secure and elegant way, I am happy for you suggestion. Otherwise, thanks for your consideration!