### PR TITLE
Remove Duplicate rules, fix FPs and Tighten a few rules

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -236,7 +236,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/comments" \
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
 # When trying to change the "Show recommendations" option in file settings
-SecRule REQUEST_FILENAME "@contains /apps/recommendations/settings/enabled" \
+SecRule REQUEST_FILENAME "@endsWith /apps/recommendations/settings/enabled" \
     "id:9508124,\
     phase:1,\
     pass,\
@@ -582,7 +582,7 @@ SecRule REQUEST_FILENAME "@endsWith /settings/users" \
 # Personal: Security
 
 # Fixes deletion and allow/disallow of filesystem access for auth tokens
-SecRule REQUEST_FILENAME "@contains /settings/personal/authtokens/" \
+SecRule REQUEST_FILENAME "@rx /settings/personal/authtokens/[0-9]+$" \
     "id:9508601,\
     phase:1,\
     pass,\
@@ -602,7 +602,7 @@ SecRule REQUEST_FILENAME "@contains /settings/api/personal/webauthn/registration
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 # While going through the first run setup wizard
-SecRule REQUEST_FILENAME "@contains /apps/firstrunwizard/wizard" \
+SecRule REQUEST_FILENAME "@endsWith /apps/firstrunwizard/wizard" \
     "id:9508607,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -632,7 +632,7 @@ SecRule REQUEST_FILENAME "@endsWith /avatar" \
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 # When trying to delete users with data access(Personal --> Privacy --> Who has access to your data?)
-SecRule REQUEST_FILENAME "@contains /apps/privacy/api/admins" \
+SecRule REQUEST_FILENAME "@rx /apps/privacy/api/admins/[0-9]+$" \
     "id:9508614,\
     phase:1,\
     pass,\
@@ -750,16 +750,6 @@ SecRule REQUEST_FILENAME "@endsWith /avatar" \
 # Disabling background
 SecRule REQUEST_FILENAME "@endsWith /apps/theming/background/custom" \
     "id:9508617,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# When deleting an admin from privacy page
-SecRule REQUEST_FILENAME "@rx /apps/privacy/api/admins/[0-9]+$" \
-    "id:9508618,\
     phase:1,\
     pass,\
     t:none,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -807,6 +807,16 @@ SecRule REQUEST_FILENAME "@endsWith /apps/theming/ajax/updateStylesheet" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=931130;ARGS:json.value"
 
+# Disabling Dyslexia font under Settings --> Appearance and Accessibility --> Dyslexia font
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/theming/api/v[0-9]/theme/opendyslexic$" \
+    "id:9508623,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
 #
 # [ Notifications ]
 #

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -26,7 +26,7 @@ SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,
 # To relax upload restrictions for only the php files that need it,
 # you put something like this in crs-setup.conf:
 #
-# SecRule REQUEST_FILENAME "@rx /(?:remote.php|index.php)/" \
+# SecRule REQUEST_FILENAME "@rx /(?:remote\.php|index\.php)/" \
 #   "id:9508600,\
 #   phase:2,\
 #   t:none,\
@@ -158,7 +158,7 @@ SecRule REQUEST_FILENAME "@beginsWith /remote.php/dav/versions/" \
 # File manager: system tags
 # Allow the data type 'text/plain'
 # Since the content is actually XML, we switch on the XML parser
-SecRule REQUEST_FILENAME "@rx ^/remote.php/dav/systemtags(?:-relations)?/" \
+SecRule REQUEST_FILENAME "@rx ^/remote\.php/dav/systemtags(?:-relations)?/" \
     "id:9508112,\
     phase:1,\
     pass,\
@@ -220,7 +220,7 @@ SecRule REQUEST_FILENAME "@endsWith /apps/text/session/create" \
 # FP while trying to open text files in file manager
 # Adding/editing comments to files
 # The content of comments could be anything
-SecRule REQUEST_FILENAME "@rx /remote.php/dav/comments/files/[0-9]+(?:/[0-9]+)?$" \
+SecRule REQUEST_FILENAME "@rx /remote\.php/dav/comments/files(?:/[0-9]+)+$" \
     "id:9508123,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -208,7 +208,7 @@ SecRule REQUEST_METHOD "@streq REPORT" \
 
 # FP when NextCloud default app "Text" detects text files in file manager.
 # PUT - When the "Text" app tries to create a session in file manager.
-SecRule REQUEST_FILENAME "@contains /apps/text/session/create" \
+SecRule REQUEST_FILENAME "@endsWith /apps/text/session/create" \
     "id:9508122,\
     phase:1,\
     pass,\
@@ -218,13 +218,16 @@ SecRule REQUEST_FILENAME "@contains /apps/text/session/create" \
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 
 # FP while trying to open text files in file manager
-SecRule REQUEST_FILENAME "@contains /remote.php/dav/comments" \
+# Adding/editing comments to files
+# The content of comments could be anything
+SecRule REQUEST_FILENAME "@rx /remote.php/dav/comments/files/[0-9]+(?:/[0-9]+)?$" \
     "id:9508123,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.message,\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
 # When trying to change the "Show recommendations" option in file settings
@@ -239,7 +242,7 @@ SecRule REQUEST_FILENAME "@endsWith /apps/recommendations/settings/enabled" \
 
 # Text app autosave sync feature doesn't work
 # ARGS:json.documentState FP was introduced in Nextcloud 26, it's triggered when selecting different note entries.
-SecRule REQUEST_URI "@contains /apps/text/session/sync" \
+SecRule REQUEST_URI "@endsWith /apps/text/session/sync" \
     "id:9508126,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -946,7 +946,7 @@ SecRule REQUEST_FILENAME "@contains /config/apps/ransomware_protection/extension
 #
 
 # Note name and content can be anything
-SecRule REQUEST_FILENAME "@rx /index\.php/apps/notes/api/v[0-9]/notes" \
+SecRule REQUEST_FILENAME "@rx /index\.php/apps/notes/api/v[0-9]/notes(?:/[0-9]+)?$" \
     "id:9508910,\
     phase:1,\
     pass,\
@@ -956,10 +956,20 @@ SecRule REQUEST_FILENAME "@rx /index\.php/apps/notes/api/v[0-9]/notes" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.title"
 
+# Creating/renaming note catagories
+SecRule REQUEST_FILENAME "@rx /apps/notes/notes/[0-9]+/(?:category|title|favorite)$" \
+    "id:9508911,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
 # Note name and content can be anything
 # PUT - when making changes/creating notes
 # DELETE - when notes are deleted
-SecRule REQUEST_FILENAME "@contains /apps/notes/notes/" \
+SecRule REQUEST_FILENAME "@rx /apps/notes/notes/[0-9]+(?:/autotitle)?$" \
     "id:9508920,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1286,7 +1286,7 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/trustedsenders/[^/]+$" \
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
 # Adding/Removing trusted senders ending in com or inc under Nextcloud Mail --> Account settings --> Trusted senders
-SecRule REQUEST_FILENAME "@rx /apps/mail/api/trustedsenders/[^/]+\.(com|inc)$" \
+SecRule REQUEST_FILENAME "@rx /apps/mail/api/trustedsenders/[^/]+\.(?:com|inc)$" \
     "id:9508988,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -127,7 +127,7 @@ SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
 
 # Allow the data type 'text/vcard'
 # Allow characters like /../ in files.
-# Allow all kind of filetypes.
+# Allow all filetypes.
 # Allow source code.
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9508110,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -282,6 +282,18 @@ SecRule REQUEST_FILENAME "@endsWith /apps/text/session/push" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS"
 
+# Viewing files within the trashbin
+# Content is XML so the XML parser is switched on
+SecRule REQUEST_FILENAME "@rx /remote\.php/dav/trashbin/[^/]+/trash/$" \
+    "id:9508170,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:requestBodyProcessor=XML,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
+
 #
 # [ Searchengine ]
 #

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -294,6 +294,27 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/trashbin/[^/]+/trash/$" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
+# Entering a password for a password protected share
+SecRule REQUEST_FILENAME "@rx /s/[^/]+/authenticate/showShare$" \
+    "id:9508171,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0'"
+
+# Sharing a file/folder
+# Fix FP when creating a share with a password
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/files_sharing/api/v[0-9]/shares/[0-9]+$" \
+    "id:9508172,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0'"
+
 #
 # [ Searchengine ]
 #

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -126,7 +126,7 @@ SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
         ctl:ruleRemoveById=921110"
 
 # Allow the data type 'text/vcard'
-# Allow characters like /../ in files.
+# Allow path traversal characters like /../ in file paths.
 # Allow all filetypes.
 # Allow source code.
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -732,16 +732,6 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9]
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
-# Deleting an avatar
-SecRule REQUEST_FILENAME "@endsWith /avatar" \
-    "id:9508616,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
 # Disabling background
 SecRule REQUEST_FILENAME "@endsWith /apps/theming/background/custom" \
     "id:9508617,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -126,6 +126,9 @@ SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
         ctl:ruleRemoveById=921110"
 
 # Allow the data type 'text/vcard'
+# Allow characters like /../ in files.
+# Allow all kind of filetypes.
+# Allow source code.
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9508110,\
     phase:1,\
@@ -133,6 +136,10 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveById=930100-930110,\
+    ctl:ruleRemoveById=951000-951999,\
+    ctl:ruleRemoveById=953100-953130,\
+    ctl:ruleRemoveById=920440,\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain| |text/vcard|'"
 
 # File manager: versioning
@@ -185,21 +192,6 @@ SecRule REQUEST_METHOD "@streq PUT" \
     SecRule REQUEST_FILENAME "@rx /(?:public\.php/webdav|remote\.php/dav/uploads)/" \
         "ctl:ruleRemoveById=920340,\
         ctl:ruleRemoveById=920420"
-
-# Allow characters like /../ in files.
-# Allow all kind of filetypes.
-# Allow source code.
-SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
-    "id:9508120,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveById=930100-930110,\
-    ctl:ruleRemoveById=951000-951999,\
-    ctl:ruleRemoveById=953100-953130,\
-    ctl:ruleRemoveById=920440"
 
 # Allow REPORT requests without Content-Type header (at least the iOS app does this)
 SecRule REQUEST_METHOD "@streq REPORT" \


### PR DESCRIPTION
This PR fixes the following
1. Marks capturing group regex as non capturing
2. Tighten rule exclusion rules to be more precise
3. Fix FP when disabling dyslexia font
4. Fix FP when viewing the trashbin
5. Fix FP with Sharing files/folders
6. Remove duplicate rules