### PR TITLE
fix FP for photos app (albums, sharedalbums, places)

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1227,7 +1227,7 @@ SecRule REQUEST_FILENAME "@rx /apps/photos/api/v[0-9]+/preview/[0-9]+$" \
 # Photos: Albums, Shared Albums, Places
 # Allow the data type 'text/plain'
 # Since the content is actually XML, we switch on the XML parser
-SecRule REQUEST_FILENAME "@rx ^/remote\.php/dav/photos/(?:[a-zA-Z0-9\-\_\. \@]|\%40)*/(?:(?:shared)?albums|places)/" \
+SecRule REQUEST_FILENAME "@rx /remote\.php/dav/photos/[^/]+/(?:albums|sharedalbums|places)(?:/[^/]+)?/$" \
     "id:9508952,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1224,6 +1224,22 @@ SecRule REQUEST_FILENAME "@rx /apps/photos/api/v[0-9]+/preview/[0-9]+$" \
         "t:none,\
         ctl:ruleRemoveById=950100"
 
+# Photos: Albums, Shared Albums, Places
+# Allow the data type 'text/plain'
+# Since the content is actually XML, we switch on the XML parser
+SecRule REQUEST_FILENAME "@rx ^/remote\.php/dav/photos/(?:[a-zA-Z0-9\-\_\. \@]|\%40)*/(?:(?:shared)?albums|places)/" \
+    "id:9508952,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    chain"
+    SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain(?:\;charset=UTF-8)?$" \
+        "t:none,\
+        ctl:requestBodyProcessor=XML,\
+        setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
+
 #
 # [ Nextcloud Files ]
 #


### PR DESCRIPTION
Allow text/plain and switch on XML parser for /remote.php/dav/photos/\<username\>/albums|sharedalbums|places.

Please review the username regex ([allowed characters](https://docs.nextcloud.com/server/latest/admin_manual/configuration_user/user_configuration.html#creating-a-new-user)). I'm not sure if the urlencoded '@' character is necessary.