### PR TITLE
fix: don't inspect REQUEST_FILENAME of uploads

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -129,6 +129,7 @@ SecRule REQUEST_METHOD "@pm PROPFIND PUT" \
 # Allow path traversal characters like /../ in file paths.
 # Allow all filetypes.
 # Allow source code.
+# Allow arbitrary filenames.
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9508110,\
     phase:1,\
@@ -140,6 +141,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     ctl:ruleRemoveById=951000-951999,\
     ctl:ruleRemoveById=953100-953130,\
     ctl:ruleRemoveById=920440,\
+    ctl:ruleRemoveTargetById=933210;REQUEST_FILENAME,\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain| |text/vcard|'"
 
 # File manager: versioning
@@ -317,19 +319,6 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/files/[^/]+/$" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
     SecRule RESPONSE_STATUS "@rx ^50(?:3|2)$" \
-        "t:none,\
-        ctl:ruleRemoveById=950100"
-
-# Syncing files with Nextcloud desktop app
-SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
-    "id:9508174,\
-    phase:3,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    chain"
-    SecRule RESPONSE_STATUS "@streq 500" \
         "t:none,\
         ctl:ruleRemoveById=950100"
 

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -310,7 +310,11 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/files_sharing/api/v[0-9]/sha
     ver:'nextcloud-rule-exclusions-plugin/1.0.0'"
 
 # Syncing files with Nextcloud desktop app
-SecRule REQUEST_FILENAME "@rx /remote\.php/dav/files/[^/]+/$" \
+# Matches:
+# - /remote.php/dav/files/username/
+# - /remote.php/dav/files/path/to/example.txt (does not assume that
+#   all files must have an extension)
+SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     "id:9508173,\
     phase:3,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -322,7 +322,7 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule RESPONSE_STATUS "@rx ^50(?:3|2)$" \
+    SecRule RESPONSE_STATUS "@rx ^50[023]$" \
         "t:none,\
         ctl:ruleRemoveById=950100"
 


### PR DESCRIPTION
- Ignore PHP injections on file names during uploads
- Remove duplicate rule

Fixes #38