### PR TITLE
refact: move NC files exclusion to file manager

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -326,6 +326,46 @@ SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
         "t:none,\
         ctl:ruleRemoveById=950100"
 
+# Expanding share menus under Files --> Shares
+SecRule REQUEST_FILENAME "@rx /apps/files/api/v[0-9]/views/shareoverview/expanded$" \
+    "id:9508960,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Changing settings within Nextcloud Files
+SecRule REQUEST_FILENAME "@rx /apps/files/api/v[0-9]/config/(?:show_hidden|crop_image_previews)$" \
+    "id:9508961,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Changing sorting direction in Nextcloud Files
+SecRule REQUEST_FILENAME "@rx /apps/files/api/v[0-9]/views/(?:trashbin|files)/sorting_(?:direction|mode)$" \
+    "id:9508962,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Rejecting a file ownership transfer
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/files/api/v[0-9]/transferownership/[0-9]+$" \
+    "id:9508963,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
 #
 # [ Searchengine ]
 #
@@ -1323,50 +1363,6 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/recognize/[^/]+/faces/(?:[0-9]+/)
         "t:none,\
         ctl:requestBodyProcessor=XML,\
         setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
-
-#
-# [ Nextcloud Files ]
-#
-
-# Expanding share menus under Files --> Shares
-SecRule REQUEST_FILENAME "@rx /apps/files/api/v[0-9]/views/shareoverview/expanded$" \
-    "id:9508960,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# Changing settings within Nextcloud Files
-SecRule REQUEST_FILENAME "@rx /apps/files/api/v[0-9]/config/(?:show_hidden|crop_image_previews)$" \
-    "id:9508961,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# Changing sorting direction in Nextcloud Files
-SecRule REQUEST_FILENAME "@rx /apps/files/api/v[0-9]/views/(?:trashbin|files)/sorting_(?:direction|mode)$" \
-    "id:9508962,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# Rejecting a file ownership transfer
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/files/api/v[0-9]/transferownership/[0-9]+$" \
-    "id:9508963,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 #
 # [ Nextcloud Mail ]


### PR DESCRIPTION
Moves rule exclusions under the catagory Nextcloud Files to File Manager, they are both the same thing. I haven't touched any of the rule IDs.