### PR TITLE
fix: SecAction can't be disabled via ctl action

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -785,7 +785,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users(?:/[^/]+)?$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.value"
 
 # Fix Nextcloud Cookie FPs
-SecRule REQUEST_FILENAME "@beginsWith /" \
+SecRule REQUEST_FILENAME "@unconditionalMatch" \
     "id:9508510,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -879,6 +879,8 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users(?:/[^/]+)?$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.value"
 
 # Fix Nextcloud Cookie FPs
+# Operator @unconditionalMatch is used instead of a SecAction because of a bug
+# in ModSecurity v3 which prevents SecActions to be removed using ctl action.
 SecRule REQUEST_FILENAME "@unconditionalMatch" \
     "id:9508510,\
     phase:1,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -785,7 +785,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users(?:/[^/]+)?$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.value"
 
 # Fix Nextcloud Cookie FPs
-SecAction \
+SecRule REQUEST_FILENAME "@beginsWith /" \
     "id:9508510,\
     phase:1,\
     pass,\


### PR DESCRIPTION
SecAction rules can't be disabled via a ctl action or run time rule exclusion
This can be problematic in reverse proxy deployments where you only want to enable the Nextcloud plugin for your Nextcloud domain.
This PR fixes that by replacing the SecAction with a SecRule that's functionally the exact same, except now it can be disabled via a ctl action.