### PR TITLE
fix: xml parser failure when restoring file to old version

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -182,8 +182,11 @@ SecRule REQUEST_FILENAME "@beginsWith /remote.php/dav/versions/" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:requestBodyProcessor=XML,\
-    setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
+    chain"
+    SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain(?:\;charset=UTF-8)?$" \
+        "t:none,\
+        ctl:requestBodyProcessor=XML,\
+        setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
 # File manager: system tags
 # Allow the data type 'text/plain'

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -183,7 +183,7 @@ SecRule REQUEST_FILENAME "@beginsWith /remote.php/dav/versions/" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain(?:\;charset=UTF-8)?$" \
+    SecRule REQUEST_HEADERS:Content-Type "@beginsWith text/plain" \
         "t:none,\
         ctl:requestBodyProcessor=XML,\
         setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
@@ -199,7 +199,7 @@ SecRule REQUEST_FILENAME "@rx ^/remote\.php/dav/systemtags(?:-relations)?/" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain(?:\;charset=UTF-8)?$" \
+    SecRule REQUEST_HEADERS:Content-Type "@beginsWith text/plain" \
         "t:none,\
         ctl:requestBodyProcessor=XML,\
         setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
@@ -311,7 +311,7 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/trashbin/[^/]+/trash/" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain(?:\;charset=UTF-8)?$" \
+    SecRule REQUEST_HEADERS:Content-Type "@beginsWith text/plain" \
         "t:none,\
         chain"
         SecRule REQUEST_METHOD "@streq PROPFIND" \
@@ -1391,7 +1391,7 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/photos/[^/]+/(?:albums|sharedalbu
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain(?:\;charset=UTF-8)?$" \
+    SecRule REQUEST_HEADERS:Content-Type "@beginsWith text/plain" \
         "t:none,\
         ctl:requestBodyProcessor=XML,\
         setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
@@ -1406,7 +1406,7 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/recognize/[^/]+/faces/(?:[0-9]+/)
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule REQUEST_HEADERS:Content-Type "@rx ^text/plain(?:\;charset=UTF-8)?$" \
+    SecRule REQUEST_HEADERS:Content-Type "@beginsWith text/plain" \
         "t:none,\
         ctl:requestBodyProcessor=XML,\
         setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"


### PR DESCRIPTION
this fixes a regression when restoring a file to an older version by only using the xml parser for text/plain content type