### PR TITLE
Fix: False positive in deck application

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1338,6 +1338,21 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/user_status/api/v[0-9]+/use
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
 #
+# [ Nextcloud Deck ]
+#
+
+# Moving a card in Deck app
+SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder$" \
+    "id:9508810,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+#
 # [ Users ]
 #
 
@@ -1915,18 +1930,3 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/outbox/(?:from-draft/)?[0-9]+$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.subject"
-
-#
-# [ Nextcloud Deck ]
-#
-
-# Moving a card in Deck app
-SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder$" \
-    "id:9508993,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1916,8 +1916,12 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/outbox/(?:from-draft/)?[0-9]+$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.subject"
 
-# Moving a card in Deck application
-SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder?$" \
+#
+# [ Nextcloud Deck ]
+#
+
+# Moving a card in Deck app
+SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder$" \
     "id:9508993,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1915,3 +1915,14 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/outbox/(?:from-draft/)?[0-9]+$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.subject"
+
+# Moving a card in Deck application
+SecRule REQUEST_FILENAME "@rx /apps/deck/cards/[0-9]+/reorder?$" \
+    "id:9508993,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Jean-Kevin Kpadey"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508993.yaml
+  name: 9508810.yaml
 tests:
-  - test_title: 9508993-1
+  - test_title: 9508810-1
     desc: |
       Moving cards on Deck apps.
       Target: description
@@ -26,4 +26,4 @@ tests:
               Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).
           output:
             no_log_contains: |
-              id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"|id "949110"|id "980130"
+              id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
@@ -20,7 +20,10 @@ tests:
             port: 80
             method: PUT
             uri: /apps/deck/cards/1/reorder
-            data: "description=This is a description.\n\nUse this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).\n"
+            data: |
+              description=This is a description.
+              
+              Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).
           output:
             no_log_contains: |
-              id"911100"|id "93(?:[23]2[10]0)"|id "94(?:2[234][03467]0|9110)"|id "980130"
+              id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"|id "949110"|id "980130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
@@ -22,7 +22,7 @@ tests:
             uri: /apps/deck/cards/1/reorder
             data: |
               description=This is a description.
-              
+
               Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).
           output:
             no_log_contains: |

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508993.yaml
@@ -1,0 +1,26 @@
+---
+meta:
+  author: "Jean-Kevin Kpadey"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508993.yaml
+tests:
+  - test_title: 9508993-1
+    desc: |
+      Moving cards on Deck apps.
+      Target: description
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP ModSecurity Core Rule Set
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: PUT
+            uri: /apps/deck/cards/1/reorder
+            data: "description=This is a description.\n\nUse this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).\n"
+          output:
+            no_log_contains: |
+              id"911100"|id "93(?:[23]2[10]0)"|id "94(?:2[234][03467]0|9110)"|id "980130"


### PR DESCRIPTION
I created this PR to handle false positive when using the deck application in nextcloud

When moving a card,the PUT method is not allowed.
Content of arg "description" triggers multiple rules.