### PR TITLE
fix: text editor in public share and token related FPs

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -244,7 +244,7 @@ SecRule REQUEST_METHOD "@streq REPORT" \
 
 # FP when NextCloud default app "Text" detects text files in file manager.
 # PUT - When the "Text" app tries to create a session in file manager.
-SecRule REQUEST_FILENAME "@endsWith /apps/text/session/create" \
+SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/create$" \
     "id:9508122,\
     phase:1,\
     pass,\
@@ -277,7 +277,6 @@ SecRule REQUEST_FILENAME "@endsWith /apps/recommendations/settings/enabled" \
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 
 # Text app autosave sync feature doesn't work
-# ARGS:json.documentState FP was introduced in Nextcloud 26, it's triggered when selecting different note entries.
 SecRule REQUEST_URI "@rx /apps/text/(?:public/)?session/sync$" \
     "id:9508126,\
     phase:1,\
@@ -285,8 +284,9 @@ SecRule REQUEST_URI "@rx /apps/text/(?:public/)?session/sync$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
-    ctl:ruleRemoveTargetById=941100;ARGS:json.documentState,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.autosaveContent,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:autosaveContent"
 
@@ -536,6 +536,88 @@ SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     ctl:ruleRemoveTargetById=921110-921160;ARGS:filecontents,\
     ctl:ruleRemoveTargetById=932150;ARGS:filename,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:filecontents"
+
+# Keeping track of client session within a text editor
+# Matches:
+# /apps/text/session/sync
+# /apps/text/session/close
+# /apps/text/session/push
+# /apps/text/public/session/sync
+# /apps/text/public/session/close
+# /apps/text/public/session/push
+# /apps/text/attachments
+SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?(?:session/(?:sync|close|push)|attachments)$" \
+    "id:9508311,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    chain"
+    SecRule ARGS:json.sessionToken "@rx ^(?i)[a-z0-9+/]+$" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=920273;ARGS:json.sessionToken,\
+        ctl:ruleRemoveTargetById=932236;ARGS:json.sessionToken,\
+        ctl:ruleRemoveTargetById=942432;ARGS:json.sessionToken,\
+        ctl:ruleRemoveTargetById=942450;ARGS:json.sessionToken"
+
+# Syncing client side document state
+SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/(?:sync|close|push)$" \
+    "id:9508312,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932236;ARGS:json.documentState,\
+    ctl:ruleRemoveTargetById=941100;ARGS:json.documentState,\
+    ctl:ruleRemoveTargetById=942210;ARGS:json.documentState,\
+    ctl:ruleRemoveTargetById=942432;ARGS:json.documentState,\
+    ctl:ruleRemoveTargetById=942450;ARGS:json.documentState"
+
+# Guest Token
+# This value is null for non public shares
+SecRule REQUEST_FILENAME "@rx /apps/text/public/session(?:sync|close|push)$" \
+    "id:9508313,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    chain"
+    SecRule ARGS:token "@rx ^(?i)[a-z0-9]+$" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=932236;ARGS:json.token,\
+        ctl:ruleRemoveTargetById=942450;ARGS:json.token"
+
+# Sending awareness messages
+# This is used for document collaboration
+SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/push$" \
+    "id:9508314,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    chain"
+    SecRule ARGS:awareness "@rx ^(?i)[a-z0-9=]+$" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=932236;ARGS:json.awareness,\
+        ctl:ruleRemoveTargetById=942450;ARGS:json.awareness"
+
+# Checking for attachemnts on public shares
+SecRule REQUEST_FILENAME "@endsWith /apps/text/attachments" \
+    "id:9508315,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    chain"
+    SecRule ARGS:json.shareToken "@rx ^(?i)[a-z0-9]+$" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=932236;ARGS:json.shareToken,\
+        ctl:ruleRemoveTargetById=942450;ARGS:json.shareToken"
 
 #
 # [ Address Book ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -576,7 +576,7 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/(?:sync|close|push)
     ctl:ruleRemoveTargetById=942450;ARGS:json.documentState"
 
 # Guest Token
-# This value is null for non public shares
+# This value is null for non public shares, so only remove the target for public ones
 SecRule REQUEST_FILENAME "@rx /apps/text/public/session(?:sync|close|push)$" \
     "id:9508313,\
     phase:2,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -602,9 +602,9 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/push$" \
     chain"
     SecRule ARGS:awareness "@rx ^(?i)[a-z0-9=+/]+$" \
         "t:none,\
-        ctl:ruleRemoveTargetById=920273;ARGS:json.sessionToken,\
+        ctl:ruleRemoveTargetById=920273;ARGS:json.awareness,\
         ctl:ruleRemoveTargetById=932236;ARGS:json.awareness,\
-        ctl:ruleRemoveTargetById=942432;ARGS:json.sessionToken,\
+        ctl:ruleRemoveTargetById=942432;ARGS:json.awareness,\
         ctl:ruleRemoveTargetById=942450;ARGS:json.awareness"
 
 # Checking for attachemnts on public shares

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -600,9 +600,11 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/push$" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:awareness "@rx ^(?i)[a-z0-9=]+$" \
+    SecRule ARGS:awareness "@rx ^(?i)[a-z0-9=+/]+$" \
         "t:none,\
+        ctl:ruleRemoveTargetById=920273;ARGS:json.sessionToken,\
         ctl:ruleRemoveTargetById=932236;ARGS:json.awareness,\
+        ctl:ruleRemoveTargetById=942432;ARGS:json.sessionToken,\
         ctl:ruleRemoveTargetById=942450;ARGS:json.awareness"
 
 # Checking for attachemnts on public shares

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508122.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508122.yaml
@@ -16,8 +16,20 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
-            uri: |
-              /apps/text/session/create
-              /apps/text/public/session/create
+            uri: /apps/text/session/create
+          output:
+            no_log_contains: id "911100"
+  - test_title: 9508122-2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: PUT
+            uri: /apps/text/public/session/create
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508122.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508122.yaml
@@ -1,0 +1,23 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Text Editor: Opening a file"
+  enabled: true
+  name: 9508122.yaml
+tests:
+  - test_title: 9508122-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: PUT
+            uri: |
+              /apps/text/session/create
+              /apps/text/public/session/create
+          output:
+            no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
@@ -16,14 +16,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: |
-              /apps/text/session/sync
-              /apps/text/session/close
-              /apps/text/session/push
-              /apps/text/public/session/sync
-              /apps/text/public/session/close
-              /apps/text/public/session/push
-              /apps/text/attachments
+            uri: /apps/text/session/sync
             data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
           output:
             no_log_contains: |
@@ -39,14 +32,199 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: |
-              /apps/text/session/sync
-              /apps/text/session/close
-              /apps/text/session/push
-              /apps/text/public/session/sync
-              /apps/text/public/session/close
-              /apps/text/public/session/push
-              /apps/text/attachments
+            uri: /apps/text/session/close
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-4
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-5
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-6
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-7
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/attachments
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-8
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/sync
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-9
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/close
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-10
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-11
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-12
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-13
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-14
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/attachments
             data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
           output:
             no_log_contains: |

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
@@ -1,0 +1,231 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Text Editor: Keeping track of client session within a text editor"
+  enabled: true
+  name: 9508311.yaml
+tests:
+  - test_title: 9508311-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/sync
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/close
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-4
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-5
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-6
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-7
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/attachments
+            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508311-8
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/sync
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-9
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/close
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-10
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-11
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-12
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-13
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508311-14
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/attachments
+            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
@@ -16,7 +16,14 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: /apps/text/session/sync
+            uri: |
+              /apps/text/session/sync
+              /apps/text/session/close
+              /apps/text/session/push
+              /apps/text/public/session/sync
+              /apps/text/public/session/close
+              /apps/text/public/session/push
+              /apps/text/attachments
             data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
           output:
             no_log_contains: |
@@ -32,199 +39,14 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: /apps/text/session/close
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508311-3
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/push
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508311-4
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/sync
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508311-5
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/close
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508311-6
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/push
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508311-7
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/attachments
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508311-8
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/sync
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508311-9
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/close
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508311-10
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/push
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508311-11
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/sync
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508311-12
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/close
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508311-13
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/push
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508311-14
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/attachments
+            uri: |
+              /apps/text/session/sync
+              /apps/text/session/close
+              /apps/text/session/push
+              /apps/text/public/session/sync
+              /apps/text/public/session/close
+              /apps/text/public/session/push
+              /apps/text/attachments
             data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
           output:
             no_log_contains: |

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
@@ -16,13 +16,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: |
-              /apps/text/session/sync
-              /apps/text/session/close
-              /apps/text/session/push
-              /apps/text/public/session/sync
-              /apps/text/public/session/close
-              /apps/text/public/session/push
+            uri: /apps/text/session/sync
             data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
           output:
             no_log_contains: |
@@ -38,13 +32,167 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: |
-              /apps/text/session/sync
-              /apps/text/session/close
-              /apps/text/session/push
-              /apps/text/public/session/sync
-              /apps/text/public/session/close
-              /apps/text/public/session/push
+            uri: /apps/text/session/close
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-4
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-5
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-6
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-7
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/sync
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-8
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/close
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-9
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-10
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-11
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-12
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
             data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
           output:
             no_log_contains: |

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
@@ -1,0 +1,199 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Text Editor: Syncing client side document state"
+  enabled: true
+  name: 9508312.yaml
+tests:
+  - test_title: 9508312-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/sync
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/close
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-4
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-5
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-6
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
+  - test_title: 9508312-7
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/sync
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-8
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/close
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-9
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-10
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-11
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
+  - test_title: 9508312-12
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+          output:
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
@@ -16,7 +16,13 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: /apps/text/session/sync
+            uri: |
+              /apps/text/session/sync
+              /apps/text/session/close
+              /apps/text/session/push
+              /apps/text/public/session/sync
+              /apps/text/public/session/close
+              /apps/text/public/session/push
             data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
           output:
             no_log_contains: |
@@ -32,167 +38,13 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: /apps/text/session/close
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508312-3
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/push
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508312-4
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/sync
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508312-5
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/close
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508312-6
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/push
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942432"
-  - test_title: 9508312-7
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/sync
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508312-8
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/close
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508312-9
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/push
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508312-10
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/sync
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508312-11
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/close
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
-          output:
-            no_log_contains: |
-              id "920273"|id "942432"|id "942450"
-  - test_title: 9508312-12
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/push
+            uri: |
+              /apps/text/session/sync
+              /apps/text/session/close
+              /apps/text/session/push
+              /apps/text/public/session/sync
+              /apps/text/public/session/close
+              /apps/text/public/session/push
             data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
           output:
             no_log_contains: |

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
@@ -1,0 +1,97 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Text Editor: Guest Token"
+  enabled: true
+  name: 9508313.yaml
+tests:
+  - test_title: 9508313-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.token=ls78sdf"
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508313-2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.token=ls78sdf"
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508313-3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.token=ls78sdf"
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508313-4
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.token=0x0800dsf78dgf"
+          output:
+            no_log_contains: id "942450"
+  - test_title: 9508313-5
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.token=0x0800dsf78dgf"
+          output:
+            no_log_contains: id "942450"
+  - test_title: 9508313-6
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.token=0x0800dsf78dgf"
+          output:
+            no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
@@ -16,7 +16,10 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: /apps/text/public/session/sync
+            uri: |
+              /apps/text/public/session/sync
+              /apps/text/public/session/close
+              /apps/text/public/session/push
             data: "json.token=ls78sdf"
           output:
             no_log_contains: id "932236"
@@ -31,67 +34,10 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: /apps/text/public/session/close
-            data: "json.token=ls78sdf"
-          output:
-            no_log_contains: id "932236"
-  - test_title: 9508313-3
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/push
-            data: "json.token=ls78sdf"
-          output:
-            no_log_contains: id "932236"
-  - test_title: 9508313-4
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/sync
-            data: "json.token=0x0800dsf78dgf"
-          output:
-            no_log_contains: id "942450"
-  - test_title: 9508313-5
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/close
-            data: "json.token=0x0800dsf78dgf"
-          output:
-            no_log_contains: id "942450"
-  - test_title: 9508313-6
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/push
+            uri: |
+              /apps/text/public/session/sync
+              /apps/text/public/session/close
+              /apps/text/public/session/push
             data: "json.token=0x0800dsf78dgf"
           output:
             no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
@@ -16,10 +16,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: |
-              /apps/text/public/session/sync
-              /apps/text/public/session/close
-              /apps/text/public/session/push
+            uri: /apps/text/public/session/sync
             data: "json.token=ls78sdf"
           output:
             no_log_contains: id "932236"
@@ -34,10 +31,67 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: |
-              /apps/text/public/session/sync
-              /apps/text/public/session/close
-              /apps/text/public/session/push
+            uri: /apps/text/public/session/close
+            data: "json.token=ls78sdf"
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508313-3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.token=ls78sdf"
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508313-4
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/sync
+            data: "json.token=0x0800dsf78dgf"
+          output:
+            no_log_contains: id "942450"
+  - test_title: 9508313-5
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/close
+            data: "json.token=0x0800dsf78dgf"
+          output:
+            no_log_contains: id "942450"
+  - test_title: 9508313-6
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
             data: "json.token=0x0800dsf78dgf"
           output:
             no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
@@ -16,9 +16,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: |
-              /apps/text/session/push
-              /apps/text/public/session/push
+            uri: /apps/text/session/push
             data: "json.awareness=lsbuas8df0bsd0789fsd07a98fnnuin="
           output:
             no_log_contains: id "932236"
@@ -33,9 +31,37 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: |
-              /apps/text/session/push
-              /apps/text/public/session/push
+            uri: /apps/text/public/session/push
+            data: "json.awareness=lsbuas8df0bsd0789fsd07a98fnnuin="
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508314-3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.awareness=0x0800buas8df0bsd0789fsd07a98fnnuin="
+          output:
+            no_log_contains: id "942450"
+  - test_title: 9508314-4
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
             data: "json.awareness=0x0800buas8df0bsd0789fsd07a98fnnuin="
           output:
             no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
@@ -16,7 +16,9 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: /apps/text/session/push
+            uri: |
+              /apps/text/session/push
+              /apps/text/public/session/push
             data: "json.awareness=lsbuas8df0bsd0789fsd07a98fnnuin="
           output:
             no_log_contains: id "932236"
@@ -31,37 +33,9 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
-            uri: /apps/text/public/session/push
-            data: "json.awareness=lsbuas8df0bsd0789fsd07a98fnnuin="
-          output:
-            no_log_contains: id "932236"
-  - test_title: 9508314-3
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/session/push
-            data: "json.awareness=0x0800buas8df0bsd0789fsd07a98fnnuin="
-          output:
-            no_log_contains: id "942450"
-  - test_title: 9508314-4
-    stages:
-      - stage:
-          input:
-            dest_addr: 127.0.0.1
-            headers:
-              Host: localhost
-              User-Agent: OWASP CRS
-              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-            port: 80
-            method: POST
-            uri: /apps/text/public/session/push
+            uri: |
+              /apps/text/session/push
+              /apps/text/public/session/push
             data: "json.awareness=0x0800buas8df0bsd0789fsd07a98fnnuin="
           output:
             no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
@@ -17,9 +17,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/push
-            data: "json.awareness=lsbuas8df0bsd0789fsd07a98fnnuin="
+            data: "json.awareness=lsbu+as8d/f0bsd0789fsd07a98fnnuin="
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
   - test_title: 9508314-2
     stages:
       - stage:
@@ -32,9 +33,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.awareness=lsbuas8df0bsd0789fsd07a98fnnuin="
+            data: "json.awareness=lsbu+as8d/f0bsd0789fsd07a98fnnuin="
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |
+              id "920273"|id "932236"|id "942432"
   - test_title: 9508314-3
     stages:
       - stage:
@@ -47,9 +49,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/push
-            data: "json.awareness=0x0800buas8df0bsd0789fsd07a98fnnuin="
+            data: "json.awareness=0x0800buas8d+f0bsd07/89fsd07a98fnnuin="
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"
   - test_title: 9508314-4
     stages:
       - stage:
@@ -62,6 +65,7 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.awareness=0x0800buas8df0bsd0789fsd07a98fnnuin="
+            data: "json.awareness=0x0800buas8d+f0bsd07/89fsd07a98fnnuin="
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |
+              id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
@@ -1,0 +1,67 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Text Editor: Sending awareness messages"
+  enabled: true
+  name: 9508314.yaml
+tests:
+  - test_title: 9508314-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.awareness=lsbuas8df0bsd0789fsd07a98fnnuin="
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508314-2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.awareness=lsbuas8df0bsd0789fsd07a98fnnuin="
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508314-3
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/session/push
+            data: "json.awareness=0x0800buas8df0bsd0789fsd07a98fnnuin="
+          output:
+            no_log_contains: id "942450"
+  - test_title: 9508314-4
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/public/session/push
+            data: "json.awareness=0x0800buas8df0bsd0789fsd07a98fnnuin="
+          output:
+            no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508315.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508315.yaml
@@ -1,7 +1,7 @@
 ---
 meta:
   author: "Esad Cetiner"
-  description: "Text Editor: Sending awareness messages"
+  description: "Text Editor: Checking for attachments"
   enabled: true
   name: 9508315.yaml
 tests:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508315.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508315.yaml
@@ -1,0 +1,37 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Text Editor: Sending awareness messages"
+  enabled: true
+  name: 9508315.yaml
+tests:
+  - test_title: 9508315-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/attachments
+            data: "json.shareToken=lsnus80dfsdf"
+          output:
+            no_log_contains: id "932236"
+  - test_title: 9508315-2
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: POST
+            uri: /apps/text/attachments
+            data: "json.shareToken=0x0800nsudf"
+          output:
+            no_log_contains: id "942450"


### PR DESCRIPTION
This PR mostly fixes issues with session tokens that are only an issue at PL-2 and above, but there is a fix for using the markdown test editor in public shares. 
The tests for some of these rules were very large(This PR would've been above 700 lines, but now it's about 300), so I refactored them by using a ``|`` to test against multiple URIs with the same payload, but for whatever reason the nginx regression tests are failing while the apache tests are passing.