### PR TITLE
fix: rules and tests after running at paranoia level 4

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -866,17 +866,14 @@ SecRule REQUEST_FILENAME "@endsWith /login/webauthn/finish" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=920273;ARGS,\
-    ctl:ruleRemoveTargetById=932236;ARGS,\
-    ctl:ruleRemoveTargetById=942200;ARGS,\
-    ctl:ruleRemoveTargetById=942260;ARGS,\
-    ctl:ruleRemoveTargetById=942340;ARGS,\
-    ctl:ruleRemoveTargetById=942370;ARGS,\
-    ctl:ruleRemoveTargetById=942430;ARGS,\
-    ctl:ruleRemoveTargetById=942431;ARGS,\
-    ctl:ruleRemoveTargetById=942432;ARGS,\
+    ctl:ruleRemoveTargetById=920273;ARGS:data,\
+    ctl:ruleRemoveTargetById=932236;ARGS:data,\
+    ctl:ruleRemoveTargetById=920273;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=932236;ARGS:json.data,\
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
-    ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:json.data"
 
 # Logging in via desktop app
 SecRule REQUEST_FILENAME "@rx /login/v[0-9\.]+/grant$" \
@@ -1462,17 +1459,13 @@ SecRule REQUEST_FILENAME "@endsWith /settings/api/personal/webauthn/registration
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=920273;ARGS,\
-    ctl:ruleRemoveTargetById=932236;ARGS,\
-    ctl:ruleRemoveTargetById=942200;ARGS,\
-    ctl:ruleRemoveTargetById=942260;ARGS,\
-    ctl:ruleRemoveTargetById=942340;ARGS,\
-    ctl:ruleRemoveTargetById=942370;ARGS,\
-    ctl:ruleRemoveTargetById=942421;ARGS,\
-    ctl:ruleRemoveTargetById=942430;ARGS,\
-    ctl:ruleRemoveTargetById=942431;ARGS,\
-    ctl:ruleRemoveTargetById=942432;ARGS,\
-    ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
+    ctl:ruleRemoveTargetById=920273;ARGS:data,\
+    ctl:ruleRemoveTargetById=932236;ARGS:data,\
+    ctl:ruleRemoveTargetById=920273;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=932236;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data,\
+    ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:json.data"
 
 # When a user is changing their password under settings --> Personal --> Security --> Password
 SecRule REQUEST_FILENAME "@endsWith /settings/personal/changepassword" \

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -263,6 +263,7 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/comments/files(?:/[0-9]+)+$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.message,\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
@@ -287,8 +288,8 @@ SecRule REQUEST_URI "@rx /apps/text/(?:public/)?session/sync$" \
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.autosaveContent,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:autosaveContent"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:autosaveContent,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.autosaveContent"
 
 # Text app content can be anything
 # We disable CRS for all ARGS since the paramater keeps on changing and can't be predicted
@@ -337,6 +338,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/files_sharing/api/v[0-9]/sha
     pass,\
     t:none,\
     nolog,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0'"
 
@@ -554,8 +556,12 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?(?:session/(?:sync|close|pu
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:json.sessionToken "@rx ^(?i)[a-z0-9+/]+$" \
+    SecRule ARGS:sessionToken|ARGS:json.sessionToken "@rx ^(?i)[a-z0-9+/]+$" \
         "t:none,\
+        ctl:ruleRemoveTargetById=920273;ARGS:sessionToken,\
+        ctl:ruleRemoveTargetById=932236;ARGS:sessionToken,\
+        ctl:ruleRemoveTargetById=942432;ARGS:sessionToken,\
+        ctl:ruleRemoveTargetById=942450;ARGS:sessionToken,\
         ctl:ruleRemoveTargetById=920273;ARGS:json.sessionToken,\
         ctl:ruleRemoveTargetById=932236;ARGS:json.sessionToken,\
         ctl:ruleRemoveTargetById=942432;ARGS:json.sessionToken,\
@@ -570,6 +576,13 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/(?:sync|close|push)
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932236;ARGS:documentState,\
+    ctl:ruleRemoveTargetById=932250;ARGS:documentState,\
+    ctl:ruleRemoveTargetById=920273;ARGS:documentState,\
+    ctl:ruleRemoveTargetById=941100;ARGS:documentState,\
+    ctl:ruleRemoveTargetById=942210;ARGS:documentState,\
+    ctl:ruleRemoveTargetById=942432;ARGS:documentState,\
+    ctl:ruleRemoveTargetById=942450;ARGS:documentState,\
     ctl:ruleRemoveTargetById=932236;ARGS:json.documentState,\
     ctl:ruleRemoveTargetById=932250;ARGS:json.documentState,\
     ctl:ruleRemoveTargetById=920273;ARGS:json.documentState,\
@@ -608,12 +621,17 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/push$" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:awareness "@rx ^(?i)[a-z0-9=+/]+$" \
+    SecRule ARGS:awareness|ARGS:json.awareness "@rx ^(?i)[a-z0-9=+/]+$" \
         "t:none,\
+        ctl:ruleRemoveTargetById=920273;ARGS:awareness,\
+        ctl:ruleRemoveTargetById=932236;ARGS:awareness,\
+        ctl:ruleRemoveTargetById=942432;ARGS:awareness,\
+        ctl:ruleRemoveTargetById=942450;ARGS:awareness,\
         ctl:ruleRemoveTargetById=920273;ARGS:json.awareness,\
         ctl:ruleRemoveTargetById=932236;ARGS:json.awareness,\
         ctl:ruleRemoveTargetById=942432;ARGS:json.awareness,\
-        ctl:ruleRemoveTargetById=942450;ARGS:json.awareness"
+        ctl:ruleRemoveTargetById=942450;ARGS:json.awareness,\
+        ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 # Checking for attachemnts on public shares
 SecRule REQUEST_FILENAME "@endsWith /apps/text/attachments" \
@@ -624,10 +642,14 @@ SecRule REQUEST_FILENAME "@endsWith /apps/text/attachments" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:json.shareToken "@rx ^(?i)[a-z0-9]+$" \
+    SecRule ARGS:shareToken|ARGS:json.shareToken "@rx ^(?i)[a-z0-9]+$" \
         "t:none,\
+        ctl:ruleRemoveTargetById=932236;ARGS:shareToken,\
+        ctl:ruleRemoveTargetById=942450;ARGS:shareToken,\
         ctl:ruleRemoveTargetById=932236;ARGS:json.shareToken,\
-        ctl:ruleRemoveTargetById=942450;ARGS:json.shareToken"
+        ctl:ruleRemoveTargetById=942450;ARGS:json.shareToken,\
+        ctl:ruleRemoveTargetById=932236;ARGS_NAMES:shareToken,\
+        ctl:ruleRemoveTargetById=932250;ARGS_NAMES:shareToken"
 
 #
 # [ Address Book ]
@@ -742,6 +764,7 @@ SecRule REQUEST_FILENAME "@rx /apps/calendar/v[0-9]/appointment_configs/[0-9]+$"
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.description,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
@@ -753,6 +776,7 @@ SecRule REQUEST_FILENAME "@rx /apps/calendar/v[0-9]/appointment_configs$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.description"
 
 # XML Parser fails when emptying calendar trashbin
@@ -831,8 +855,8 @@ SecRule REQUEST_FILENAME "@endsWith /login/confirm" \
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password"
 
 # When logging in via FIDO2
 SecRule REQUEST_FILENAME "@endsWith /login/webauthn/finish" \
@@ -894,6 +918,7 @@ SecRule REQUEST_FILENAME "@rx /lostpassword/set/[^/]+/[^/]+$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password"
 
 # requesttoken is used when logging in or when authenticating via a public share
@@ -971,6 +996,8 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users(?:/[^/]+)?$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.value"
 
@@ -1414,6 +1441,7 @@ SecRule REQUEST_FILENAME "@endsWith /apps/theming/ajax/updateStylesheet" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=931130;ARGS:value,\
     ctl:ruleRemoveTargetById=931130;ARGS:json.value"
 
 # Disabling Dyslexia font under Settings --> Appearance and Accessibility --> Dyslexia font
@@ -1454,6 +1482,8 @@ SecRule REQUEST_FILENAME "@endsWith /settings/personal/changepassword" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:oldpassword,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newpassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.oldpassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.newpassword"
 
@@ -1465,6 +1495,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/password_policy/api/v[0-9]/v
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password"
 
 # Adjusting the amount of cores used for AI facial recognition under Settings --> Administration --> Recognize --> CPU Cores
@@ -1475,6 +1506,7 @@ SecRule REQUEST_FILENAME "@rx /apps/recognize/admin/settings/(?:tensorflow\.(?:c
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=932160;ARGS:value,\
     ctl:ruleRemoveTargetById=932160;ARGS:json.value,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 
@@ -1487,6 +1519,8 @@ SecRule REQUEST_FILENAME "@rx /apps/oauth2/clients(?:/[0-9]+)?$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=931130;ARGS:redirectUri,\
+    ctl:ruleRemoveTargetById=932236;ARGS:name,\
     ctl:ruleRemoveTargetById=931130;ARGS:json.redirectUri,\
     ctl:ruleRemoveTargetById=932236;ARGS:json.name,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
@@ -1545,6 +1579,7 @@ SecRule REQUEST_FILENAME "@endsWith /index.php/apps/richdocuments/ajax/admin.php
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=931130;ARGS:wopi_url,\
     ctl:ruleRemoveTargetById=931130;ARGS:json.wopi_url"
 
 #
@@ -1679,6 +1714,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users/$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=931130;ARGS:value,\
     ctl:ruleRemoveTargetById=931130;ARGS:json.value"
 
 #
@@ -1766,6 +1802,8 @@ SecRule REQUEST_FILENAME "@rx /index\.php/apps/notes/api/v[0-9]/notes(?:/[0-9]+)
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.title"
 
@@ -1789,6 +1827,8 @@ SecRule REQUEST_FILENAME "@rx /apps/notes/notes/[0-9]+(?:/autotitle)?$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:content,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:title,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.content,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.title,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
@@ -1841,6 +1881,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/circles/circles/[^/]+/settin
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:value,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.value"
 
 #
@@ -1977,6 +2018,8 @@ SecRule REQUEST_FILENAME "@endsWith /apps/mail/api/accounts" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:imapPassword,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:smtpPassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.imapPassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.smtpPassword"
 
@@ -2023,6 +2066,8 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/accounts/[0-9]+/draft$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editorBody,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.body"
 
@@ -2034,6 +2079,8 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/outbox(?:/[0-9]+)?$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editorBody,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.body,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
@@ -2083,6 +2130,14 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/preferences/(?:tag-classified-messa
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=920273;ARGS:value,\
+    ctl:ruleRemoveTargetById=932236;ARGS:value,\
+    ctl:ruleRemoveTargetById=942200;ARGS:value,\
+    ctl:ruleRemoveTargetById=942260;ARGS:value,\
+    ctl:ruleRemoveTargetById=942421;ARGS:value,\
+    ctl:ruleRemoveTargetById=942430;ARGS:value,\
+    ctl:ruleRemoveTargetById=942431;ARGS:value,\
+    ctl:ruleRemoveTargetById=942432;ARGS:value,\
     ctl:ruleRemoveTargetById=920273;ARGS:json.value,\
     ctl:ruleRemoveTargetById=932236;ARGS:json.value,\
     ctl:ruleRemoveTargetById=942200;ARGS:json.value,\
@@ -2102,6 +2157,10 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/settings/provisioning(?:/[0-9]+)?$"
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=920230;ARGS:data.sieveUser,\
+    ctl:ruleRemoveTargetById=920230;ARGS:data.imapUser,\
+    ctl:ruleRemoveTargetById=920230;ARGS:data.smtpUser,\
+    ctl:ruleRemoveTargetById=920230;ARGS:data.emailTemplate,\
     ctl:ruleRemoveTargetById=920230;ARGS:json.data.sieveUser,\
     ctl:ruleRemoveTargetById=920230;ARGS:json.data.imapUser,\
     ctl:ruleRemoveTargetById=920230;ARGS:json.data.smtpUser,\
@@ -2147,6 +2206,7 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/sieve/account/[0-9]+$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:sievePassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.sievePassword,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 
@@ -2201,6 +2261,11 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/drafts(?:/[0-9]+|/\{id\})?$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:data.body.value,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:data.editorBody,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editorBody,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:subject,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.data.body.value,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.data.editorBody,\
@@ -2218,6 +2283,9 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/outbox/(?:from-draft/)?[0-9]+$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:body,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:editorBody,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:subject,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.body,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.editorBody,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.subject"

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -556,7 +556,7 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?(?:session/(?:sync|close|pu
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:sessionToken|ARGS:json.sessionToken "@rx ^(?i)[a-z0-9+/]+$" \
+    SecRule ARGS:sessionToken|ARGS:json.sessionToken "@rx (?i)^[a-z0-9+/]+$" \
         "t:none,\
         ctl:ruleRemoveTargetById=920273;ARGS:sessionToken,\
         ctl:ruleRemoveTargetById=932236;ARGS:sessionToken,\
@@ -602,7 +602,7 @@ SecRule REQUEST_FILENAME "@rx /apps/text/public/session/(?:sync|close|push)$" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:token|ARGS:json.token "@rx ^(?i)[a-z0-9]+$" \
+    SecRule ARGS:token|ARGS:json.token "@rx (?i)^[a-z0-9]+$" \
         "t:none,\
         ctl:ruleRemoveTargetById=932236;ARGS:token,\
         ctl:ruleRemoveTargetById=932250;ARGS:token,\
@@ -621,7 +621,7 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/push$" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:awareness|ARGS:json.awareness "@rx ^(?i)[a-z0-9=+/]+$" \
+    SecRule ARGS:awareness|ARGS:json.awareness "@rx (?i)^[a-z0-9=+/]+$" \
         "t:none,\
         ctl:ruleRemoveTargetById=920273;ARGS:awareness,\
         ctl:ruleRemoveTargetById=932236;ARGS:awareness,\
@@ -642,7 +642,7 @@ SecRule REQUEST_FILENAME "@endsWith /apps/text/attachments" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:shareToken|ARGS:json.shareToken "@rx ^(?i)[a-z0-9]+$" \
+    SecRule ARGS:shareToken|ARGS:json.shareToken "@rx (?i)^[a-z0-9]+$" \
         "t:none,\
         ctl:ruleRemoveTargetById=932236;ARGS:shareToken,\
         ctl:ruleRemoveTargetById=942450;ARGS:shareToken,\
@@ -867,9 +867,9 @@ SecRule REQUEST_FILENAME "@endsWith /login/webauthn/finish" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=920273;ARGS:data,\
-    ctl:ruleRemoveTargetById=932236;ARGS:data,\
+    ctl:ruleRemoveTargetById=932236;ARGS:data
     ctl:ruleRemoveTargetById=920273;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=932236;ARGS:json.data,\
+    ctl:ruleRemoveTargetById=932236;ARGS:json.data
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data,\
@@ -884,7 +884,7 @@ SecRule REQUEST_FILENAME "@rx /login/v[0-9\.]+/grant$" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:stateToken "@rx ^(?i)[a-z0-9]+$" \
+    SecRule ARGS:stateToken "@rx (?i)^[a-z0-9]+$" \
         "t:none,\
         ctl:ruleRemoveTargetById=932236;ARGS:stateToken,\
         ctl:ruleRemoveTargetById=942450;ARGS:stateToken"
@@ -933,7 +933,7 @@ SecRule REQUEST_FILENAME "@rx /login(?:/v[0-9\.]+/grant)?|s/[^/]+/authenticate/s
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:requesttoken "@rx ^(?i)[a-z0-9+=/]+:[a-z0-9+=/]+$" \
+    SecRule ARGS:requesttoken "@rx (?i)^[a-z0-9+=/]+:[a-z0-9+=/]+$" \
         "t:none,\
         ctl:ruleRemoveTargetById=920273;ARGS:requesttoken,\
         ctl:ruleRemoveTargetById=932236;ARGS:requesttoken,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -869,7 +869,7 @@ SecRule REQUEST_FILENAME "@endsWith /login/webauthn/finish" \
     ctl:ruleRemoveTargetById=920273;ARGS:data,\
     ctl:ruleRemoveTargetById=932236;ARGS:data,\
     ctl:ruleRemoveTargetById=920273;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=932236;ARGS:json.data
+    ctl:ruleRemoveTargetById=932236;ARGS:json.data,\
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -867,7 +867,7 @@ SecRule REQUEST_FILENAME "@endsWith /login/webauthn/finish" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=920273;ARGS:data,\
-    ctl:ruleRemoveTargetById=932236;ARGS:data
+    ctl:ruleRemoveTargetById=932236;ARGS:data,\
     ctl:ruleRemoveTargetById=920273;ARGS:json.data,\
     ctl:ruleRemoveTargetById=932236;ARGS:json.data
     ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -559,7 +559,8 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?(?:session/(?:sync|close|pu
         ctl:ruleRemoveTargetById=920273;ARGS:json.sessionToken,\
         ctl:ruleRemoveTargetById=932236;ARGS:json.sessionToken,\
         ctl:ruleRemoveTargetById=942432;ARGS:json.sessionToken,\
-        ctl:ruleRemoveTargetById=942450;ARGS:json.sessionToken"
+        ctl:ruleRemoveTargetById=942450;ARGS:json.sessionToken,\
+        ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 # Syncing client side document state
 SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/(?:sync|close|push)$" \
@@ -570,14 +571,17 @@ SecRule REQUEST_FILENAME "@rx /apps/text/(?:public/)?session/(?:sync|close|push)
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     ctl:ruleRemoveTargetById=932236;ARGS:json.documentState,\
+    ctl:ruleRemoveTargetById=932250;ARGS:json.documentState,\
+    ctl:ruleRemoveTargetById=920273;ARGS:json.documentState,\
     ctl:ruleRemoveTargetById=941100;ARGS:json.documentState,\
     ctl:ruleRemoveTargetById=942210;ARGS:json.documentState,\
     ctl:ruleRemoveTargetById=942432;ARGS:json.documentState,\
-    ctl:ruleRemoveTargetById=942450;ARGS:json.documentState"
+    ctl:ruleRemoveTargetById=942450;ARGS:json.documentState,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 # Guest Token
 # This value is null for non public shares, so only remove the target for public ones
-SecRule REQUEST_FILENAME "@rx /apps/text/public/session(?:sync|close|push)$" \
+SecRule REQUEST_FILENAME "@rx /apps/text/public/session/(?:sync|close|push)$" \
     "id:9508313,\
     phase:2,\
     pass,\
@@ -585,9 +589,13 @@ SecRule REQUEST_FILENAME "@rx /apps/text/public/session(?:sync|close|push)$" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:token "@rx ^(?i)[a-z0-9]+$" \
+    SecRule ARGS:token|ARGS:json.token "@rx ^(?i)[a-z0-9]+$" \
         "t:none,\
+        ctl:ruleRemoveTargetById=932236;ARGS:token,\
+        ctl:ruleRemoveTargetById=932250;ARGS:token,\
+        ctl:ruleRemoveTargetById=942450;ARGS:token,\
         ctl:ruleRemoveTargetById=932236;ARGS:json.token,\
+        ctl:ruleRemoveTargetById=932250;ARGS:json.token,\
         ctl:ruleRemoveTargetById=942450;ARGS:json.token"
 
 # Sending awareness messages
@@ -834,15 +842,17 @@ SecRule REQUEST_FILENAME "@endsWith /login/webauthn/finish" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=920273;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=932236;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942200;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942260;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942340;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942370;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942430;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942431;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942432;ARGS:json.data"
+    ctl:ruleRemoveTargetById=920273;ARGS,\
+    ctl:ruleRemoveTargetById=932236;ARGS,\
+    ctl:ruleRemoveTargetById=942200;ARGS,\
+    ctl:ruleRemoveTargetById=942260;ARGS,\
+    ctl:ruleRemoveTargetById=942340;ARGS,\
+    ctl:ruleRemoveTargetById=942370;ARGS,\
+    ctl:ruleRemoveTargetById=942430;ARGS,\
+    ctl:ruleRemoveTargetById=942431;ARGS,\
+    ctl:ruleRemoveTargetById=942432;ARGS,\
+    ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 # Logging in via desktop app
 SecRule REQUEST_FILENAME "@rx /login/v[0-9\.]+/grant$" \
@@ -887,12 +897,13 @@ SecRule REQUEST_FILENAME "@rx /lostpassword/set/[^/]+/[^/]+$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password"
 
 # requesttoken is used when logging in or when authenticating via a public share
+# format: two base64 encoded byte strings, separated by colon
 # Matches:
 # /login
 # /s/share-id/authenticate/showShare
 # /login/v2/grant
 # /logout
-SecRule REQUEST_FILENAME "@rx /(?:login(?:/v[0-9\.]+/grant)?|s/[^/]+/authenticate/showShare|logout)$" \
+SecRule REQUEST_FILENAME "@rx /login(?:/v[0-9\.]+/grant)?|s/[^/]+/authenticate/showShare|logout$" \
     "id:9508420,\
     phase:2,\
     pass,\
@@ -900,14 +911,15 @@ SecRule REQUEST_FILENAME "@rx /(?:login(?:/v[0-9\.]+/grant)?|s/[^/]+/authenticat
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
     chain"
-    SecRule ARGS:requesttoken "@rx ^(?i)[a-z0-9+=:/]+$" \
+    SecRule ARGS:requesttoken "@rx ^(?i)[a-z0-9+=/]+:[a-z0-9+=/]+$" \
         "t:none,\
         ctl:ruleRemoveTargetById=920273;ARGS:requesttoken,\
         ctl:ruleRemoveTargetById=932236;ARGS:requesttoken,\
         ctl:ruleRemoveTargetById=941100;ARGS:requesttoken,\
         ctl:ruleRemoveTargetById=941120;ARGS:requesttoken,\
         ctl:ruleRemoveTargetById=942432;ARGS:requesttoken,\
-        ctl:ruleRemoveTargetById=942450;ARGS:requesttoken"
+        ctl:ruleRemoveTargetById=942450;ARGS:requesttoken,\
+        ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 # Logging in with webauthn
 # HTTP 500 error code may sometimes be returned when authenticating
@@ -1422,16 +1434,17 @@ SecRule REQUEST_FILENAME "@endsWith /settings/api/personal/webauthn/registration
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
-    ctl:ruleRemoveTargetById=920273;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=932236;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942200;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942260;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942340;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942370;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942421;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942430;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942431;ARGS:json.data,\
-    ctl:ruleRemoveTargetById=942432;ARGS:json.data"
+    ctl:ruleRemoveTargetById=920273;ARGS,\
+    ctl:ruleRemoveTargetById=932236;ARGS,\
+    ctl:ruleRemoveTargetById=942200;ARGS,\
+    ctl:ruleRemoveTargetById=942260;ARGS,\
+    ctl:ruleRemoveTargetById=942340;ARGS,\
+    ctl:ruleRemoveTargetById=942370;ARGS,\
+    ctl:ruleRemoveTargetById=942421;ARGS,\
+    ctl:ruleRemoveTargetById=942430;ARGS,\
+    ctl:ruleRemoveTargetById=942431;ARGS,\
+    ctl:ruleRemoveTargetById=942432;ARGS,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 # When a user is changing their password under settings --> Personal --> Security --> Password
 SecRule REQUEST_FILENAME "@endsWith /settings/personal/changepassword" \
@@ -2034,6 +2047,7 @@ SecRule REQUEST_FILENAME "@rx /apps/mail/api/messages/[0-9]+/flags$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.0.0',\
+    ctl:ruleRemoveTargetById=942290;ARGS_NAMES:flags.$notjunk,\
     ctl:ruleRemoveTargetById=942290;ARGS_NAMES:json.flags.$notjunk,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
@@ -14,10 +14,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/sync
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+            data_raw: "json.sessionToken=lsh8u9sd+dfsdaf/89"
           output:
             no_log_contains: |
               id "920273"|id "932236"|id "942432"
@@ -30,6 +31,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/close
@@ -46,6 +48,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/push
@@ -62,6 +65,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
@@ -78,6 +82,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/close
@@ -94,6 +99,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/push
@@ -110,6 +116,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/attachments
@@ -126,6 +133,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/sync
@@ -142,6 +150,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/close
@@ -158,6 +167,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/push
@@ -174,6 +184,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
@@ -190,6 +201,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/close
@@ -206,6 +218,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/push
@@ -222,6 +235,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/attachments

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
@@ -18,9 +18,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/sync
-            data_raw: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+            data: |
+              {"sessionToken": "lsh8u9sd+dfsdaf/89"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508311-2
     stages:
@@ -35,9 +36,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/close
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+            data: |
+              {"sessionToken": "lsh8u9sd+dfsdaf/89"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508311-3
     stages:
@@ -52,9 +54,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/push
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+            data: |
+              {"sessionToken": "lsh8u9sd+dfsdaf/89"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508311-4
     stages:
@@ -69,9 +72,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+            data: |
+              {"sessionToken": "lsh8u9sd+dfsdaf/89"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508311-5
     stages:
@@ -86,9 +90,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/close
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+            data: |
+              {"sessionToken": "lsh8u9sd+dfsdaf/89"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508311-6
     stages:
@@ -103,9 +108,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+            data: |
+              {"sessionToken": "lsh8u9sd+dfsdaf/89"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508311-7
     stages:
@@ -120,9 +126,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/attachments
-            data: "json.sessionToken=lsh8u9sd+dfsdaf/89"
+            data: |
+              {"sessionToken": "lsh8u9sd+dfsdaf/89"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508311-8
     stages:
@@ -137,9 +144,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/sync
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+            data: |
+              {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508311-9
     stages:
@@ -154,9 +162,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/close
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+            data: |
+              {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508311-10
     stages:
@@ -171,9 +180,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/push
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+            data: |
+              {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508311-11
     stages:
@@ -188,9 +198,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+            data: |
+              {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508311-12
     stages:
@@ -205,9 +216,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/close
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+            data: |
+              {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508311-13
     stages:
@@ -222,9 +234,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+            data: |
+              {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508311-14
     stages:
@@ -239,7 +252,8 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/attachments
-            data: "json.sessionToken=0x0800b7098sdbf+sdfJB76/nsidf878B"
+            data: |
+              {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
@@ -18,9 +18,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/sync
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508312-2
     stages:
@@ -35,9 +36,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/close
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508312-3
     stages:
@@ -52,9 +54,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/push
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508312-4
     stages:
@@ -69,9 +72,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508312-5
     stages:
@@ -86,9 +90,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/close
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508312-6
     stages:
@@ -103,9 +108,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.documentState=lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508312-7
     stages:
@@ -120,9 +126,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/sync
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508312-8
     stages:
@@ -137,9 +144,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/close
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508312-9
     stages:
@@ -154,9 +162,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/push
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508312-10
     stages:
@@ -171,9 +180,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508312-11
     stages:
@@ -188,9 +198,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/close
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508312-12
     stages:
@@ -205,7 +216,8 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.documentState=0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="
+            data: |
+              {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
@@ -14,6 +14,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/sync
@@ -30,6 +31,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/close
@@ -46,6 +48,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/push
@@ -62,6 +65,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
@@ -78,6 +82,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/close
@@ -94,6 +99,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/push
@@ -110,6 +116,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/sync
@@ -126,6 +133,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/close
@@ -142,6 +150,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/push
@@ -158,6 +167,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
@@ -174,6 +184,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/close
@@ -190,6 +201,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/push

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
@@ -14,6 +14,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
@@ -29,6 +30,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/close
@@ -44,6 +46,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/push
@@ -59,6 +62,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
@@ -74,6 +78,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/close
@@ -89,6 +94,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/push

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
@@ -18,9 +18,11 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
-            data: "json.token=ls78sdf"
+            data: |
+              {"token": "ls78sdf"}
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "932236"|id "932250"|id "942450"
   - test_title: 9508313-2
     stages:
       - stage:
@@ -34,9 +36,11 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/close
-            data: "json.token=ls78sdf"
+            data: |
+              {"token": "ls78sdf"}
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "932236"|id "932250"|id "942450"
   - test_title: 9508313-3
     stages:
       - stage:
@@ -50,9 +54,11 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.token=ls78sdf"
+            data: |
+              {"token": "ls78sdf"}
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "932236"|id "932250"|id "942450"
   - test_title: 9508313-4
     stages:
       - stage:
@@ -66,9 +72,11 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/sync
-            data: "json.token=0x0800dsf78dgf"
+            data: |
+              {"token": "0x0800dsf78dgf"}
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "932236"|id "932250"|id "942450"
   - test_title: 9508313-5
     stages:
       - stage:
@@ -82,9 +90,11 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/close
-            data: "json.token=0x0800dsf78dgf"
+            data: |
+              {"token": "0x0800dsf78dgf"}
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "932236"|id "932250"|id "942450"
   - test_title: 9508313-6
     stages:
       - stage:
@@ -98,6 +108,8 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.token=0x0800dsf78dgf"
+            data: |
+              {"token": "0x0800dsf78dgf"}
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "932236"|id "932250"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
@@ -18,9 +18,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/push
-            data: "json.awareness=lsbu+as8d/f0bsd0789fsd07a98fnnuin="
+            data: |
+              {"awareness": "lsbu+as8d/f0bsd0789fsd07a98fnnuin="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508314-2
     stages:
@@ -35,9 +36,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.awareness=lsbu+as8d/f0bsd0789fsd07a98fnnuin="
+            data: |
+              {"awareness": "lsbu+as8d/f0bsd0789fsd07a98fnnuin="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942432"
   - test_title: 9508314-3
     stages:
@@ -52,9 +54,10 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/session/push
-            data: "json.awareness=0x0800buas8d+f0bsd07/89fsd07a98fnnuin="
+            data: |
+              {"awareness": "0x0800buas8d+f0bsd07/89fsd07a98fnnuin="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"
   - test_title: 9508314-4
     stages:
@@ -69,7 +72,8 @@ tests:
             port: 80
             method: POST
             uri: /apps/text/public/session/push
-            data: "json.awareness=0x0800buas8d+f0bsd07/89fsd07a98fnnuin="
+            data: |
+              {"awareness": "0x0800buas8d+f0bsd07/89fsd07a98fnnuin="}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
@@ -14,6 +14,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/push
@@ -30,6 +31,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/push
@@ -46,6 +48,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/session/push
@@ -62,6 +65,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/public/session/push

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508315.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508315.yaml
@@ -14,10 +14,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/attachments
-            data: "json.shareToken=lsnus80dfsdf"
+            data: |
+              {"shareToken": "lsnus80dfsdf"}
           output:
             no_log_contains: id "932236"
   - test_title: 9508315-2
@@ -29,9 +31,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/text/attachments
-            data: "json.shareToken=0x0800nsudf"
+            data: |
+              {"shareToken": "0x0800nsudf"}
           output:
             no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508400.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508400.yaml
@@ -53,7 +53,7 @@ tests:
             data: "redirect_url=/login/v2/grant?user=Esad%20Cetiner&stateToken=sample-token"
           output:
             no_log_contains: |-
-              id "920230"|id "932(?:19|20)0"|id "94243[12]"
+              id "(?:920230|932190|932200|942431|942432)"
   - test_title: 9508400-4
     desc: Desktop app redirecting to web gui to authenticate without pretty URLs
     stages:
@@ -70,4 +70,4 @@ tests:
             data: "redirect_url=/login/v2/grant?user=Esad%20Cetiner&stateToken=sample-token"
           output:
             no_log_contains: |-
-              id "920230"|id "932(?:19|20)0"|id "94243[12]"
+              id "(?:920230|932190|932200|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508400.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508400.yaml
@@ -52,7 +52,7 @@ tests:
             uri: /login
             data: "redirect_url=/login/v2/grant?user=Esad%20Cetiner&stateToken=sample-token"
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920230"|id "932(?:19|20)0"|id "94243[12]"
   - test_title: 9508400-4
     desc: Desktop app redirecting to web gui to authenticate without pretty URLs
@@ -69,5 +69,5 @@ tests:
             uri: /index.php/login
             data: "redirect_url=/login/v2/grant?user=Esad%20Cetiner&stateToken=sample-token"
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920230"|id "932(?:19|20)0"|id "94243[12]"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508401.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508401.yaml
@@ -15,10 +15,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login/confirm
-            data: "password=<script>"
+            data: |
+              {"password": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508401-2
@@ -31,10 +33,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login/confirm
-            data: "json.password=<script>"
+            data: |
+              {"password": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508401-3
@@ -47,10 +51,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login/confirm
-            data: "password=<script>"
+            data: |
+              {"password": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508401-4
@@ -63,9 +69,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login/confirm
-            data: "json.password=<script>"
+            data: |
+              {"password": "<script>"}
           output:
             no_log_contains: id "941101"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
@@ -20,10 +20,10 @@ tests:
             method: POST
             uri: /login/webauthn/finish
             data: |
-              json.data={"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}
+              {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
           output:
-            no_log_contains: |
-              id"920273"|id "932236"|id "942(?:2[06]0|3[47]0|43[012])"
+            no_log_contains: |-
+              id "(?:"920273|932236|942200|942260|942340|942370|94243[012])"
   - test_title: 9508402-2
     desc: Logging in via webauthn without pretty URLs
     stages:
@@ -39,7 +39,7 @@ tests:
             method: POST
             uri: /index.php/login/webauthn/finish
             data: |
-              json.data={"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}
+              {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
           output:
-            no_log_contains: |
-              id "920273"|id "932236"|id "942(?:2[06]0|3[47]0|43[012])"
+            no_log_contains: |-
+              id "(?:"920273|932236|942200|942260|942340|942370|94243[012])"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
@@ -20,7 +20,7 @@ tests:
             method: POST
             uri: /login/webauthn/finish
             data: |
-              {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
+              {"data":"{\"id\":\"RanDom__02Data\",\"type\":\"public-key\",\"rawId\":\"FDADG34//fsd88DF=\",\"response\":{\"authenticatorData\":\"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==\",\"clientDataJSON\":\"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==\",\"signature\":\"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=\",\"userHandle\":\"random="}}"}
           output:
             no_log_contains: |-
               id "(?:"920273|932236|942200|942260|942340|942370|942430|942431|942432)"
@@ -39,7 +39,7 @@ tests:
             method: POST
             uri: /index.php/login/webauthn/finish
             data: |
-              {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
+              {"data":"{\"id\":\"RanDom__02Data\",\"type\":\"public-key\",\"rawId\":\"FDADG34//fsd88DF=\",\"response\":{\"authenticatorData\":\"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==\",\"clientDataJSON\":\"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==\",\"signature\":\"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=\",\"userHandle\":\"random="}}"}
           output:
             no_log_contains: |-
               id "(?:"920273|932236|942200|942260|942340|942370|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
@@ -15,6 +15,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login/webauthn/finish
@@ -33,6 +34,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login/webauthn/finish

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
@@ -23,7 +23,7 @@ tests:
               {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
           output:
             no_log_contains: |-
-              id "(?:"920273|932236|942200|942260|942340|942370|94243[012])"
+              id "(?:"920273|932236|942200|942260|942340|942370|942430|942431|942432)"
   - test_title: 9508402-2
     desc: Logging in via webauthn without pretty URLs
     stages:
@@ -42,4 +42,4 @@ tests:
               {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
           output:
             no_log_contains: |-
-              id "(?:"920273|932236|942200|942260|942340|942370|94243[012])"
+              id "(?:"920273|932236|942200|942260|942340|942370|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508411.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508411.yaml
@@ -15,10 +15,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /lostpassword/set/random/username
-            data: "json.password=<script>"
+            data: |
+              {"password": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508411-2
@@ -31,9 +33,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/lostpassword/set/random/username
-            data: "json.password=<script>"
+            data: |
+              {"password": "<script>"}
           output:
             no_log_contains: id "941101"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508420.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508420.yaml
@@ -15,6 +15,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login
@@ -31,6 +32,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login
@@ -47,6 +49,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login
@@ -63,6 +66,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login
@@ -79,6 +83,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login
@@ -95,6 +100,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login
@@ -111,6 +117,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login
@@ -127,6 +134,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login
@@ -143,6 +151,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /logout
@@ -159,6 +168,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /logout
@@ -175,6 +185,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /logout
@@ -191,6 +202,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /logout
@@ -207,6 +219,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/logout
@@ -223,6 +236,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/logout
@@ -239,6 +253,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/logout
@@ -255,6 +270,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/logout
@@ -271,6 +287,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
@@ -287,6 +304,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
@@ -303,6 +321,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
@@ -319,6 +338,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
@@ -335,6 +355,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
@@ -351,6 +372,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
@@ -367,6 +389,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
@@ -383,6 +406,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
@@ -399,6 +423,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login/v2/grant
@@ -415,6 +440,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login/v2/grant
@@ -431,6 +457,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login/v2/grant
@@ -447,6 +474,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /login/v2/grant
@@ -463,6 +491,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
@@ -479,6 +508,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
@@ -495,6 +525,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
@@ -511,6 +542,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/login/v2/grant

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508420.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508420.yaml
@@ -1,12 +1,17 @@
 ---
 meta:
   author: "Esad Cetiner"
-  description: "FP when sending login token"
+  description: |
+    FP when sending login token.
+    The token consists of two base64 encoded byte strings, separated by a colon.
+    The token is URL encoded as part of the request.
   enabled: true
   name: 9508420.yaml
 tests:
   - test_title: 9508420-1
-    desc: logging in with pretty URLs
+    desc: |
+      logging in with pretty URLs
+      Payload: lds:978+/dfdsa
     stages:
       - stage:
           input:
@@ -15,15 +20,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login
-            data: "requesttoken=lds:978+/dfdsa"
+            data: "requesttoken=lds%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "920273"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-2
-    desc: logging in with pretty URLs
+    desc: |
+      logging in with pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -32,15 +40,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-3
-    desc: logging in with pretty URLs
+    desc: |
+      logging in with pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -49,15 +60,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "942432"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-4
-    desc: logging in with pretty URLs
+    desc: |
+      logging in with pretty URLs
+      Payload: 0x800:fds+/dsfsda
     stages:
       - stage:
           input:
@@ -66,15 +80,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login
-            data: "requesttoken=0x800:fds+/dsfsda"
+            data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-5
-    desc: logging in without pretty URLs
+    desc: |
+      logging in without pretty URLs
+      Payload: lds:978+/dfdsa
     stages:
       - stage:
           input:
@@ -83,15 +100,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login
-            data: "requesttoken=lds:978+/dfdsa"
+            data: "requesttoken=lds%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "920273"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-6
-    desc: logging in without pretty URLs
+    desc: |
+      logging in without pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -100,15 +120,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-7
-    desc: logging in without pretty URLs
+    desc: |
+      logging in without pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -117,15 +140,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "942432"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-8
-    desc: logging in without pretty URLs
+    desc: |
+      logging in without pretty URLs
+      Payload: 0x800:fds+/dsfsda
     stages:
       - stage:
           input:
@@ -134,15 +160,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login
-            data: "requesttoken=0x800:fds+/dsfsda"
+            data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-9
-    desc: logging out with pretty URLs
+    desc: |
+      logging out with pretty URLs
+      Payload: lds:978+/dfdsa
     stages:
       - stage:
           input:
@@ -151,15 +180,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /logout
-            data: "requesttoken=lds:978+/dfdsa"
+            data: "requesttoken=lds%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "920273"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-10
-    desc: logging out with pretty URLs
+    desc: |
+      logging out with pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -168,15 +200,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /logout
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-11
-    desc: logging out with pretty URLs
+    desc: |
+      logging out with pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -185,15 +220,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /logout
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "942432"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-12
-    desc: logging out with pretty URLs
+    desc: |
+      logging out with pretty URLs
+      Payload: 0x800:fds+/dsfsda
     stages:
       - stage:
           input:
@@ -202,15 +240,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /logout
-            data: "requesttoken=0x800:fds+/dsfsda"
+            data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-13
-    desc: logging out without pretty URLs
+    desc: |
+      logging out without pretty URLs
+      Payload: lds:978+/dfdsa
     stages:
       - stage:
           input:
@@ -219,15 +260,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/logout
-            data: "requesttoken=lds:978+/dfdsa"
+            data: "requesttoken=lds%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "920273"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-14
-    desc: logging out without pretty URLs
+    desc: |
+      logging out without pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -236,15 +280,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/logout
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-15
-    desc: logging out without pretty URLs
+    desc: |
+      logging out without pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -253,15 +300,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/logout
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "942432"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-16
-    desc: logging out without pretty URLs
+    desc: |
+      logging out without pretty URLs
+      Payload: 0x800:fds+/dsfsda
     stages:
       - stage:
           input:
@@ -270,15 +320,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/logout
-            data: "requesttoken=0x800:fds+/dsfsda"
+            data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-17
-    desc: viewing/authenticating a pubic share with pretty URLs
+    desc: |
+      viewing/authenticating a pubic share with pretty URLs
+      Payload: lds:978+/dfdsa
     stages:
       - stage:
           input:
@@ -287,15 +340,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
-            data: "requesttoken=lds:978+/dfdsa"
+            data: "requesttoken=lds%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "920273"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-18
-    desc: viewing/authenticating a pubic share with pretty URLs
+    desc: |
+      viewing/authenticating a pubic share with pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -304,15 +360,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-19
-    desc: viewing/authenticating a pubic share with pretty URLs
+    desc: |
+      viewing/authenticating a pubic share with pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -321,15 +380,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "942432"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-20
-    desc: viewing/authenticating a pubic share with pretty URLs
+    desc: |
+      viewing/authenticating a pubic share with pretty URLs
+      Payload: 0x800:fds+/dsfsda
     stages:
       - stage:
           input:
@@ -338,15 +400,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
-            data: "requesttoken=0x800:fds+/dsfsda"
+            data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-21
-    desc: viewing/authenticating a pubic share without pretty URLs
+    desc: |
+      viewing/authenticating a pubic share without pretty URLs
+      Payload: lds:978+/dfdsa
     stages:
       - stage:
           input:
@@ -355,15 +420,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
-            data: "requesttoken=lds:978+/dfdsa"
+            data: "requesttoken=lds%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "920273"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-22
-    desc: viewing/authenticating a pubic share without pretty URLs
+    desc: |
+      viewing/authenticating a pubic share without pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -372,15 +440,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-23
-    desc: viewing/authenticating a pubic share without pretty URLs
+    desc: |
+      viewing/authenticating a pubic share without pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -389,15 +460,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "942432"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-24
-    desc: viewing/authenticating a pubic share without pretty URLs
+    desc: |
+      viewing/authenticating a pubic share without pretty URLs
+      Payload: 0x800:fds+/dsfsda
     stages:
       - stage:
           input:
@@ -406,15 +480,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
-            data: "requesttoken=0x800:fds+/dsfsda"
+            data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-25
-    desc: logging into nextcloud desktop client with pretty URLs
+    desc: |
+      logging into nextcloud desktop client with pretty URLs
+      Payload: lds:978+/dfdsa
     stages:
       - stage:
           input:
@@ -423,15 +500,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login/v2/grant
-            data: "requesttoken=lds:978+/dfdsa"
+            data: "requesttoken=lds%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "920273"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-26
-    desc: logging into nextcloud desktop client with pretty URLs
+    desc: |
+      logging into nextcloud desktop client with pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -440,15 +520,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login/v2/grant
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-27
-    desc: logging into nextcloud desktop client with pretty URLs
+    desc: |
+      logging into nextcloud desktop client with pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -457,15 +540,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login/v2/grant
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "942432"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-28
-    desc: logging into nextcloud desktop client with pretty URLs
+    desc: |
+      logging into nextcloud desktop client with pretty URLs
+      Payload: 0x800:fds+/dsfsda
     stages:
       - stage:
           input:
@@ -474,15 +560,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login/v2/grant
-            data: "requesttoken=0x800:fds+/dsfsda"
+            data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-29
-    desc: logging into nextcloud desktop client without pretty URLs
+    desc: |
+      logging into nextcloud desktop client without pretty URLs
+      Payload: lds:978+/dfdsa
     stages:
       - stage:
           input:
@@ -491,15 +580,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
-            data: "requesttoken=lds:978+/dfdsa"
+            data: "requesttoken=lds%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "920273"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-30
-    desc: logging into nextcloud desktop client without pretty URLs
+    desc: |
+      logging into nextcloud desktop client without pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -508,15 +600,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "932236"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-31
-    desc: logging into nextcloud desktop client without pretty URLs
+    desc: |
+      logging into nextcloud desktop client without pretty URLs
+      Payload: lss:978+/dfdsa
     stages:
       - stage:
           input:
@@ -525,15 +620,18 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
-            data: "requesttoken=lss:978+/dfdsa"
+            data: "requesttoken=lss%3A978%2B%2Fdfdsa"
           output:
-            no_log_contains: id "942432"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"
   - test_title: 9508420-32
-    desc: logging into nextcloud desktop client without pretty URLs
+    desc: |
+      logging into nextcloud desktop client without pretty URLs
+      Payload: 0x800:fds+/dsfsda
     stages:
       - stage:
           input:
@@ -542,10 +640,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
-            data: "requesttoken=0x800:fds+/dsfsda"
+            data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
           output:
-            no_log_contains: id "942450"
+            no_log_contains: |-
+              id "(?:920273|932236|942100|942120|942432|942450)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
@@ -23,7 +23,7 @@ tests:
               {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
           output:
             no_log_contains: |-
-              id "920273"|id "932236"|id "942(?:2[06]0|3[47]0|43[012])"
+              id "(?:920273|932236|942200|942260|942340|942370|942430|942431|942432)"
   - test_title: 9508624-2
     desc: Registering webauthn device without pretty URLs
     stages:
@@ -42,4 +42,4 @@ tests:
               {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
           output:
             no_log_contains: |-
-              id "920273"|id "932236"|id "942(?:2[06]0|3[47]0|43[012])"
+              id "(?:920273|932236|942200|942260|942340|942370|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
@@ -15,6 +15,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /settings/api/personal/webauthn/registration
@@ -33,6 +34,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /settings/api/personal/webauthn/registration

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
@@ -20,7 +20,7 @@ tests:
             method: POST
             uri: /settings/api/personal/webauthn/registration
             data: |
-              {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
+              {"data":"{\"id\":\"RanDom__02Data\",\"type\":\"public-key\",\"rawId\":\"FDADG34//fsd88DF=\",\"response\":{\"authenticatorData\":\"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==\",\"clientDataJSON\":\"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==\",\"signature\":\"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=\",\"userHandle\":\"random=\"}}"}
           output:
             no_log_contains: |-
               id "(?:920273|932236|942200|942260|942340|942370|942430|942431|942432)"
@@ -39,7 +39,7 @@ tests:
             method: POST
             uri: /settings/api/personal/webauthn/registration
             data: |
-              {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
+              {"data":"{\"id\":\"RanDom__02Data\",\"type\":\"public-key\",\"rawId\":\"FDADG34//fsd88DF=\",\"response\":{\"authenticatorData\":\"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==\",\"clientDataJSON\":\"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==\",\"signature\":\"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=\",\"userHandle\":\"random=\"}}"}
           output:
             no_log_contains: |-
               id "(?:920273|932236|942200|942260|942340|942370|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
@@ -20,9 +20,9 @@ tests:
             method: POST
             uri: /settings/api/personal/webauthn/registration
             data: |
-              json.data={"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}
+              {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942(?:2[06]0|3[47]0|43[012])"
   - test_title: 9508624-2
     desc: Registering webauthn device without pretty URLs
@@ -39,7 +39,7 @@ tests:
             method: POST
             uri: /settings/api/personal/webauthn/registration
             data: |
-              json.data={"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}
+              {"data":{"id":"RanDom__02Data","type":"public-key","rawId":"FDADG34//fsd88DF=","response":{"authenticatorData":"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==","clientDataJSON":"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==","signature":"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=","userHandle":"random="}}}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920273"|id "932236"|id "942(?:2[06]0|3[47]0|43[012])"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508628.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508628.yaml
@@ -45,10 +45,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/oauth2/clients/42
-            data: "json.redirectUri=https://example.com/"
+            data: |
+              {"redirectUri": "https://example.com/"}
           output:
             no_log_contains: id "931130"
   - test_title: 9508628-4
@@ -61,9 +63,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /apps/oauth2/clients
-            data: "json.redirectUri=https://example.com/"
+            data: |
+              {"redirectUri": "https://example.com/"}
           output:
             no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508633.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508633.yaml
@@ -15,9 +15,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
             uri: /index.php/apps/richdocuments/ajax/admin.php
-            data: "json.wopi_url=https://example.com/"
+            data: |
+              {"wopi_url": "https://example.com/"}
           output:
             no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
@@ -17,15 +17,16 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/deck/cards/1/reorder
             data: |
-              description=This is a description.
+              {"description:": "This is a description.
 
-              Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen).
+              Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen)."}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"
   - test_title: 9508810-2
     desc: Unassigning a user from a card.
@@ -41,7 +42,7 @@ tests:
             method: PUT
             uri: /apps/deck/cards/1/unassign
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"
   - test_title: 9508810-3
     desc: |
@@ -60,7 +61,7 @@ tests:
             method: PUT
             uri: /apps/deck/cards/1
             data: |
-              json.data={"id":16,"title":"Title","description":"","stackId":11,"type":"plain","lastModified":1708032296,"lastEditor":null,"createdAt":1708013998,"labels":[{"id":9,"title":"Terminé","color":"31CC7C","boardId":3,"cardId":null,"lastModified":0,"ETag":"cfcd208495d565ef66e7dff9f98764da"}],"owner":{"primaryKey":"mivek","uid":"mivek","displayname":"mivek","type":0},"order":2,"duedate":"2024-02-15T23:00:00.000Z","deletedAt":0,"boardId":3}
+              {"data":{"id":16,"title":"Title","description":"","stackId":11,"type":"plain","lastModified":1708032296,"lastEditor":null,"createdAt":1708013998,"labels":[{"id":9,"title":"Terminé","color":"31CC7C","boardId":3,"cardId":null,"lastModified":0,"ETag":"cfcd208495d565ef66e7dff9f98764da"}],"owner":{"primaryKey":"mivek","uid":"mivek","displayname":"mivek","type":0},"order":2,"duedate":"2024-02-15T23:00:00.000Z","deletedAt":0,"boardId":3}}
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
@@ -55,6 +55,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/deck/cards/1

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508852.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508852.yaml
@@ -15,9 +15,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: POST
-            data: "json.value=https://example.com/"
+            data: |
+              {"value": "https://example.com/"}
             uri: /ocs/v2.php/cloud/users/
           output:
             no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508880.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508880.yaml
@@ -22,4 +22,4 @@ tests:
             data: "reference=https://www.jaycar.com.au/raspberry-pi-3-switchmode-power-supply-5-1v-2-5a-with-usb-micro-b/p/MP3536?pos=1&queryId=0a9ebf34f466c42c586d9561f4ac20d2&sort=relevance&searchText=2.5a%205v%20micro%20usb"
           output:
             no_log_contains: |-
-              id "920230"|id "93(?:1130|2200)"|id "94243[012]"
+              id "(?:920230|931130|932200|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508880.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508880.yaml
@@ -15,10 +15,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /ocs/v2.php/references/resolve
             data: "reference=https://www.jaycar.com.au/raspberry-pi-3-switchmode-power-supply-5-1v-2-5a-with-usb-micro-b/p/MP3536?pos=1&queryId=0a9ebf34f466c42c586d9561f4ac20d2&sort=relevance&searchText=2.5a%205v%20micro%20usb"
           output:
-            no_log_contains: |
+            no_log_contains: |-
               id "920230"|id "93(?:1130|2200)"|id "94243[012]"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508978.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508978.yaml
@@ -15,8 +15,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
-            uri: /apps/mail/api/messages/1/flags?json.flags.$notjunk=1
+            uri: /apps/mail/api/messages/1/flags
+            data: |
+              {"flags": {"$notjunk": 1}}
           output:
             no_log_contains: id "942290"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508991.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508991.yaml
@@ -46,7 +46,7 @@ tests:
             method: PUT
             uri: /apps/mail/api/drafts/1
             data: |
-              {"data.body.value": "<script>"}
+              {"data":{"body":{"value": "<script>"}}}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-3
@@ -68,7 +68,7 @@ tests:
             method: PUT
             uri: /apps/mail/api/drafts/1
             data: |
-              {"data.editorBody": "<script>"}
+              {"data":{"editorBody": "<script>"}}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-4
@@ -134,7 +134,7 @@ tests:
             method: PUT
             uri: /apps/mail/api/drafts/{id}
             data: |
-              {"data.body.value": "<script>"}
+              {"data":{"body":{"value": "<script>"}}}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-7
@@ -156,7 +156,7 @@ tests:
             method: PUT
             uri: /apps/mail/api/drafts/{id}
             data: |
-              {"data.editorBody": "<script>"}
+              {"data":{"editorBody": "<script>"}}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-8

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508991.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508991.yaml
@@ -19,10 +19,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/1
-            data: "json.body=<script>"
+            data: |
+              {"body": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-2
@@ -39,10 +41,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/1
-            data: "json.data.body.value=<script>"
+            data: |
+              {"data.body.value": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-3
@@ -59,10 +63,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/1
-            data: "json.data.editorBody=<script>"
+            data: |
+              {"data.editorBody": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-4
@@ -79,10 +85,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/1
-            data: "json.editorBody=<script>"
+            data: |
+              {"editorBody": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-5
@@ -99,10 +107,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/{id}
-            data: "json.body=<script>"
+            data: |
+              {"body": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-6
@@ -119,10 +129,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/{id}
-            data: "json.data.body.value=<script>"
+            data: |
+              {"data.body.value": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-7
@@ -139,10 +151,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/{id}
-            data: "json.data.editorBody=<script>"
+            data: |
+              {"data.editorBody": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-8
@@ -159,10 +173,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/{id}
-            data: "json.editorBody=<script>"
+            data: |
+              {"editorBody": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-9
@@ -178,10 +194,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/{id}
-            data: "json.subject=<script>"
+            data: |
+              {"subject": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-10
@@ -197,9 +215,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/drafts/1
-            data: "json.subject=<script>"
+            data: |
+              {"subject": "<script>"}
           output:
             no_log_contains: id "941101"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508992.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508992.yaml
@@ -18,10 +18,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/outbox/1
-            data: "json.editorBody=<script>"
+            data: |
+              {"editorBody": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-2
@@ -37,10 +39,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/outbox/1
-            data: "json.body=<script>"
+            data: |
+              {"body": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-3
@@ -55,10 +59,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/outbox/1
-            data: "json.subject=<script>"
+            data: |
+              {"subject": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-4
@@ -74,10 +80,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/outbox/from-draft/1
-            data: "json.editorBody=<script>"
+            data: |
+              {"editorBody": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-5
@@ -93,10 +101,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/outbox/from-draft/1
-            data: "json.body=<script>"
+            data: |
+              {"body": "<script>"}
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-6
@@ -111,9 +121,11 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /apps/mail/api/outbox/from-draft/1
-            data: "json.subject=<script>"
+            data: |
+              {"subject": "<script>"}
           output:
             no_log_contains: id "941101"


### PR DESCRIPTION
With the CRS v4 images, it has become apparent that plugin tests were being run at paranoia level 1. Now, they are running at paranoia level 4, revealing some mistakes in the tests and rules.