### PR TITLE
fix: caldav fp on iphone

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -718,7 +718,7 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/addressbooks/users/(?:[^/]+/){2}[
 #
 
 # Allow the data type 'text/calendar'
-SecRule REQUEST_FILENAME "@rx /remote.php/(?:cal)?dav/calendars/" \
+SecRule REQUEST_FILENAME "@rx /remote\.php/(?:cal)?dav/calendars/" \
     "id:9508330,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -461,6 +461,17 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|index|public)\.php/" \
     ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT PATCH CHECKOUT COPY DELETE LOCK MERGE MKACTIVITY MKCOL MOVE PROPFIND PROPPATCH SEARCH UNLOCK REPORT TRACE jsonp'"
 
+# Allow CalDav/CarDav clients to scan for CalDav CarDav path
+SecRule REQUEST_FILENAME "@streq /" \
+    "id:9508131,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
+
 # We need to allow DAV methods for sharing files, and removing shares
 # DELETE - when the share is removed
 # PUT - when setting a password / expiration time
@@ -805,17 +816,6 @@ SecRule REQUEST_FILENAME "@rx /remote.php/dav/calendars/[^/]+/[^/]+/$" \
     ctl:ruleRemoveTargetById=942432;XML:/*,\
     ctl:ruleRemoveTargetById=942440;XML:/*,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} MKCALENDAR'"
-
-# Allow CalDav/CarDav clients to scan for CalDav CarDav path
-SecRule REQUEST_FILENAME "@streq /" \
-    "id:9508338,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
-    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
 
 #
 # [ Notes ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -868,11 +868,11 @@ SecRule REQUEST_FILENAME "@rx ^/remote\.php/dav/calendars/[^/]+/[^/]+/?$" \
         "t:none,\
         ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
         ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
-        ctl:ruleRemoveTargetById=932236;XML:/*,\
-        ctl:ruleRemoveTargetById=942430;XML:/*,\
-        ctl:ruleRemoveTargetById=942431;XML:/*,\
-        ctl:ruleRemoveTargetById=942432;XML:/*,\
-        ctl:ruleRemoveTargetById=942440;XML:/*"
+        ctl:ruleRemoveTargetById=932236;XML,\
+        ctl:ruleRemoveTargetById=942430;XML,\
+        ctl:ruleRemoveTargetById=942431;XML,\
+        ctl:ruleRemoveTargetById=942432;XML,\
+        ctl:ruleRemoveTargetById=942440;XML"
 
 # Enabling/disabling "Enable birthday calendar setting
 # Deleting an calendar group
@@ -919,10 +919,10 @@ SecRule REQUEST_FILENAME "@rx /remote.php/dav/calendars/[^/]+/[^/]+/$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
-    ctl:ruleRemoveTargetById=942430;XML:/*,\
-    ctl:ruleRemoveTargetById=942431;XML:/*,\
-    ctl:ruleRemoveTargetById=942432;XML:/*,\
-    ctl:ruleRemoveTargetById=942440;XML:/*,\
+    ctl:ruleRemoveTargetById=942430;XML,\
+    ctl:ruleRemoveTargetById=942431;XML,\
+    ctl:ruleRemoveTargetById=942432;XML,\
+    ctl:ruleRemoveTargetById=942440;XML,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} MKCALENDAR'"
 
 #
@@ -1774,10 +1774,10 @@ SecRule REQUEST_FILENAME "@rx /remote.php/dav/calendars/[^/]+/inbox$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
-    ctl:ruleRemoveTargetById=932236;XML:/*,\
-    ctl:ruleRemoveTargetById=942430;XML:/*,\
-    ctl:ruleRemoveTargetById=942431;XML:/*,\
-    ctl:ruleRemoveTargetById=942432;XML:/*"
+    ctl:ruleRemoveTargetById=932236;XML,\
+    ctl:ruleRemoveTargetById=942430;XML,\
+    ctl:ruleRemoveTargetById=942431;XML,\
+    ctl:ruleRemoveTargetById=942432;XML"
 
 #
 # [ Notifications ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -806,6 +806,17 @@ SecRule REQUEST_FILENAME "@rx /remote.php/dav/calendars/[^/]+/[^/]+/$" \
     ctl:ruleRemoveTargetById=942440;XML:/*,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} MKCALENDAR'"
 
+# Allow CalDav/CarDav clients to scan for CalDav CarDav path
+SecRule REQUEST_FILENAME "@streq /" \
+    "id:9508338,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
+    ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
+
 #
 # [ Notes ]
 #

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -792,6 +792,20 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/calendars/[^/]+/trashbin/objects/
         "t:none,\
         ctl:ruleRemoveById=200002"
 
+# Signing into caldav via iPhone
+SecRule REQUEST_FILENAME "@rx /remote.php/dav/calendars/[^/]+/[^/]+/$" \
+    "id:9508337,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
+    ctl:ruleRemoveTargetById=942430;XML:/*,\
+    ctl:ruleRemoveTargetById=942431;XML:/*,\
+    ctl:ruleRemoveTargetById=942432;XML:/*,\
+    ctl:ruleRemoveTargetById=942440;XML:/*,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} MKCALENDAR'"
+
 #
 # [ Notes ]
 #

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -718,7 +718,7 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/addressbooks/users/(?:[^/]+/){2}[
 #
 
 # Allow the data type 'text/calendar'
-SecRule REQUEST_FILENAME "@contains /remote.php/dav/calendars/" \
+SecRule REQUEST_FILENAME "@rx /remote.php/(?:cal)?dav/calendars/" \
     "id:9508330,\
     phase:1,\
     pass,\

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508115.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508115.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /remote.php/dav/files/something
             data: |
               PDF
+            version: HTTP/1.1
           output:
             log_contains: id "920420"
   - test_title: 9508115-2
@@ -31,7 +32,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -40,6 +41,7 @@ tests:
             uri: /remote.php/nomatch
             data: |
               PDF
+            version: HTTP/1.1
           output:
             log_contains: id "920420"
   - test_title: 9508115-3
@@ -50,7 +52,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -58,6 +60,7 @@ tests:
             uri: /remote.php/dav
             data: |
               PDF
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"
   - test_title: 9508115-4
@@ -68,7 +71,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -76,6 +79,7 @@ tests:
             uri: /remote.php/dav/uploads/something
             data: |
               PDF
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"
   - test_title: 9508115-5
@@ -86,7 +90,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -94,6 +98,7 @@ tests:
             uri: /remote.php/dav/nomatch/something
             data: |
               PDF
+            version: HTTP/1.1
           output:
             log_contains: id "920420"
   - test_title: 9508115-6
@@ -104,7 +109,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -112,6 +117,7 @@ tests:
             uri: /remote.php/dav/files/something
             data: |
               PDF
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"
   - test_title: 9508115-7
@@ -122,7 +128,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/pdf
             port: 80
@@ -130,5 +136,6 @@ tests:
             uri: /remote.php/dav/uploads/something
             data: |
               PDF
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508122.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508122.yaml
@@ -12,11 +12,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /apps/text/session/create
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508122-2
@@ -26,11 +27,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /apps/text/public/session/create
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508122-3
@@ -40,11 +42,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /apps/text/session/1234/create
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508122-4
@@ -54,10 +57,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /apps/text/public/session/1234/create
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508126.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508126.yaml
@@ -16,7 +16,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -24,6 +24,7 @@ tests:
             uri: /apps/text/session/sync
             data: |
               {"documentId":1234,"sessionId":5678,"sessionToken":"randomdata","token":null,"filePath":"","version":42,"autosaveContent":"<script>2","documentState":"randomdata","force":true,"manualSave":true}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508126-2
@@ -37,7 +38,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -45,6 +46,7 @@ tests:
             uri: /apps/text/public/session/sync
             data: |
               {"documentId":1234,"sessionId":5678,"sessionToken":"randomdata","token":null,"filePath":"","version":42,"autosaveContent":"<script>2","documentState":"randomdata","force":true,"manualSave":true}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508126-3
@@ -58,7 +60,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -66,6 +68,7 @@ tests:
             uri: /apps/text/session/1234/sync
             data: |
               {"documentId":1234,"sessionId":5678,"sessionToken":"randomdata","token":null,"filePath":"","version":42,"autosaveContent":"<script>2","documentState":"randomdata","force":true,"manualSave":true}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508126-4
@@ -79,7 +82,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -87,6 +90,7 @@ tests:
             uri: /apps/text/public/session/1234/sync
             data: |
               {"documentId":1234,"sessionId":5678,"sessionToken":"randomdata","token":null,"filePath":"","version":42,"autosaveContent":"<script>2","documentState":"randomdata","force":true,"manualSave":true}
+            version: HTTP/1.1 
           output:
             no_log_contains: id "941101"
   - test_title: 9508126-5
@@ -100,7 +104,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -108,6 +112,7 @@ tests:
             uri: /apps/text/session/1234/save
             data: |
               {"documentId":1234,"sessionId":5678,"sessionToken":"randomdata","token":null,"filePath":"","version":42,"autosaveContent":"<script>2","documentState":"randomdata","force":true,"manualSave":true}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508126-6
@@ -121,7 +126,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -129,5 +134,6 @@ tests:
             uri: /apps/text/public/session/1234/save
             data: |
               {"documentId":1234,"sessionId":5678,"sessionToken":"randomdata","token":null,"filePath":"","version":42,"autosaveContent":"<script>2","documentState":"randomdata","force":true,"manualSave":true}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508126.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508126.yaml
@@ -90,7 +90,7 @@ tests:
             uri: /apps/text/public/session/1234/sync
             data: |
               {"documentId":1234,"sessionId":5678,"sessionToken":"randomdata","token":null,"filePath":"","version":42,"autosaveContent":"<script>2","documentState":"randomdata","force":true,"manualSave":true}
-            version: HTTP/1.1 
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508126-5

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508131.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508131.yaml
@@ -12,11 +12,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PROPFIND
             uri: /
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "911100"| id "921110"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508131.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508131.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Esad Cetiner"
   description: "Dav client scanning for Dav path"
   enabled: true
-  name: 9508338.yaml
+  name: 9508131.yaml
 tests:
-  - test_title: 9508338-1
+  - test_title: 9508131-1
     stages:
       - stage:
           input:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508176.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508176.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               if: stuff
             port: 80
             method: POST
             uri: /remote.php/dav/uploads/username/123/.file
+            version: HTTP/1.1
           output:
             no_log_contains: id "920450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508311.yaml
@@ -12,7 +12,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -20,6 +20,7 @@ tests:
             uri: /apps/text/session/sync
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -30,7 +31,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -38,6 +39,7 @@ tests:
             uri: /apps/text/session/close
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -48,7 +50,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -56,6 +58,7 @@ tests:
             uri: /apps/text/session/push
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -66,7 +69,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -74,6 +77,7 @@ tests:
             uri: /apps/text/public/session/sync
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -84,7 +88,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -92,6 +96,7 @@ tests:
             uri: /apps/text/public/session/close
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -102,7 +107,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -110,6 +115,7 @@ tests:
             uri: /apps/text/public/session/push
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -120,7 +126,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -128,6 +134,7 @@ tests:
             uri: /apps/text/attachments
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -138,7 +145,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -146,6 +153,7 @@ tests:
             uri: /apps/text/session/sync
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -156,7 +164,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -164,6 +172,7 @@ tests:
             uri: /apps/text/session/close
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -174,7 +183,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -182,6 +191,7 @@ tests:
             uri: /apps/text/session/push
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -192,7 +202,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -200,6 +210,7 @@ tests:
             uri: /apps/text/public/session/sync
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -210,7 +221,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -218,6 +229,7 @@ tests:
             uri: /apps/text/public/session/close
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -228,7 +240,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -236,6 +248,7 @@ tests:
             uri: /apps/text/public/session/push
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -246,7 +259,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -254,6 +267,7 @@ tests:
             uri: /apps/text/attachments
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -264,7 +278,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -272,6 +286,7 @@ tests:
             uri: /apps/text/session/1234/sync
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -282,7 +297,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -290,6 +305,7 @@ tests:
             uri: /apps/text/session/1234/close
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -300,7 +316,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -308,6 +324,7 @@ tests:
             uri: /apps/text/session/1234/push
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -318,7 +335,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -326,6 +343,7 @@ tests:
             uri: /apps/text/public/session/1234/sync
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -336,7 +354,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -344,6 +362,7 @@ tests:
             uri: /apps/text/public/session/1234/close
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -354,7 +373,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -362,6 +381,7 @@ tests:
             uri: /apps/text/public/session/1234/push
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -372,7 +392,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -380,6 +400,7 @@ tests:
             uri: /apps/text/session/1234/sync
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -390,7 +411,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -398,6 +419,7 @@ tests:
             uri: /apps/text/session/1234/close
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -408,7 +430,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -416,6 +438,7 @@ tests:
             uri: /apps/text/session/1234/push
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -426,7 +449,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -434,6 +457,7 @@ tests:
             uri: /apps/text/public/session/1234/sync
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -444,7 +468,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -452,6 +476,7 @@ tests:
             uri: /apps/text/public/session/1234/close
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -462,7 +487,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -470,6 +495,7 @@ tests:
             uri: /apps/text/public/session/1234/push
             data: |
               {"sessionToken": "0x0800b7098sdbf+sdfJB76/nsidf878B"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -480,7 +506,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -488,6 +514,7 @@ tests:
             uri: /apps/text/session/1234/save
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -498,7 +525,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -506,6 +533,7 @@ tests:
             uri: /apps/text/session/1234/save
             data: |
               {"sessionToken": "0x0800random+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -516,7 +544,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -524,6 +552,7 @@ tests:
             uri: /apps/text/public/session/1234/save
             data: |
               {"sessionToken": "lsh8u9sd+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -534,7 +563,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -542,6 +571,7 @@ tests:
             uri: /apps/text/public/session/1234/save
             data: |
               {"sessionToken": "0x0800random+dfsdaf/89"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508312.yaml
@@ -12,7 +12,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -20,6 +20,7 @@ tests:
             uri: /apps/text/session/sync
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -30,7 +31,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -38,6 +39,7 @@ tests:
             uri: /apps/text/session/close
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -48,7 +50,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -56,6 +58,7 @@ tests:
             uri: /apps/text/session/push
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -66,7 +69,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -74,6 +77,7 @@ tests:
             uri: /apps/text/public/session/sync
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -84,7 +88,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -92,6 +96,7 @@ tests:
             uri: /apps/text/public/session/close
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -102,7 +107,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -110,6 +115,7 @@ tests:
             uri: /apps/text/public/session/push
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -120,7 +126,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -128,6 +134,7 @@ tests:
             uri: /apps/text/session/sync
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -138,7 +145,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -146,6 +153,7 @@ tests:
             uri: /apps/text/session/close
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -156,7 +164,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -164,6 +172,7 @@ tests:
             uri: /apps/text/session/push
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -174,7 +183,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -182,6 +191,7 @@ tests:
             uri: /apps/text/public/session/sync
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -192,7 +202,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -200,6 +210,7 @@ tests:
             uri: /apps/text/public/session/close
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -210,7 +221,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -218,6 +229,7 @@ tests:
             uri: /apps/text/public/session/push
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -228,7 +240,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -236,6 +248,7 @@ tests:
             uri: /apps/text/session/1234/sync
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -246,7 +259,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -254,6 +267,7 @@ tests:
             uri: /apps/text/session/1234/close
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -264,7 +278,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -272,6 +286,7 @@ tests:
             uri: /apps/text/session/1234/push
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -282,7 +297,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -290,6 +305,7 @@ tests:
             uri: /apps/text/public/session/1234/sync
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -300,7 +316,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -308,6 +324,7 @@ tests:
             uri: /apps/text/public/session/1234/close
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -318,7 +335,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -326,6 +343,7 @@ tests:
             uri: /apps/text/public/session/1234/push
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -336,7 +354,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -344,6 +362,7 @@ tests:
             uri: /apps/text/session/1234/sync
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -354,7 +373,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -362,6 +381,7 @@ tests:
             uri: /apps/text/session/1234/close
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -372,7 +392,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -380,6 +400,7 @@ tests:
             uri: /apps/text/session/1234/push
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -390,7 +411,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -398,6 +419,7 @@ tests:
             uri: /apps/text/public/session/1234/sync
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -408,7 +430,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -416,6 +438,7 @@ tests:
             uri: /apps/text/public/session/1234/close
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -426,7 +449,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -434,6 +457,7 @@ tests:
             uri: /apps/text/public/session/1234/push
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -444,7 +468,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -452,6 +476,7 @@ tests:
             uri: /apps/text/session/1234/save
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -462,7 +487,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -470,6 +495,7 @@ tests:
             uri: /apps/text/session/1234/save
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -480,7 +506,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -488,6 +514,7 @@ tests:
             uri: /apps/text/public/session/1234/save
             data: |
               {"documentState": "lsgdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -498,7 +525,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -506,6 +533,7 @@ tests:
             uri: /apps/text/public/session/1234/save
             data: |
               {"documentState": "0x0800gdrsg4/dg43q/ubiisdfbUYDFSBUIbjbsdfb7sd8fuhjdf87tsdfJHDF+7p/ranbdom/sdf68nN+89s/bsdf87676gJBUIJBUIBsss+sdf7858/iubdfs77="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508313.yaml
@@ -12,7 +12,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -20,6 +20,7 @@ tests:
             uri: /apps/text/public/session/sync
             data: |
               {"token": "ls78sdf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -30,7 +31,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -38,6 +39,7 @@ tests:
             uri: /apps/text/public/session/close
             data: |
               {"token": "ls78sdf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -48,7 +50,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -56,6 +58,7 @@ tests:
             uri: /apps/text/public/session/push
             data: |
               {"token": "ls78sdf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -66,7 +69,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -74,6 +77,7 @@ tests:
             uri: /apps/text/public/session/sync
             data: |
               {"token": "0x0800dsf78dgf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -84,7 +88,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -92,6 +96,7 @@ tests:
             uri: /apps/text/public/session/close
             data: |
               {"token": "0x0800dsf78dgf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -102,7 +107,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -110,6 +115,7 @@ tests:
             uri: /apps/text/public/session/push
             data: |
               {"token": "0x0800dsf78dgf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -120,7 +126,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -128,6 +134,7 @@ tests:
             uri: /apps/text/public/session/1234/sync
             data: |
               {"token": "ls78sdf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -138,7 +145,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -146,6 +153,7 @@ tests:
             uri: /apps/text/public/session/1234/close
             data: |
               {"token": "ls78sdf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -156,7 +164,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -164,6 +172,7 @@ tests:
             uri: /apps/text/public/session/1234/push
             data: |
               {"token": "ls78sdf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -174,7 +183,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -182,6 +191,7 @@ tests:
             uri: /apps/text/public/session/1234/sync
             data: |
               {"token": "0x0800dsf78dgf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -192,7 +202,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -200,6 +210,7 @@ tests:
             uri: /apps/text/public/session/1234/close
             data: |
               {"token": "0x0800dsf78dgf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"
@@ -210,7 +221,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -218,6 +229,7 @@ tests:
             uri: /apps/text/public/session/1234/push
             data: |
               {"token": "0x0800dsf78dgf"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "932236"|id "932250"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508314.yaml
@@ -12,7 +12,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -20,6 +20,7 @@ tests:
             uri: /apps/text/session/push
             data: |
               {"awareness": "lsbu+as8d/f0bsd0789fsd07a98fnnuin="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -30,7 +31,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -38,6 +39,7 @@ tests:
             uri: /apps/text/public/session/push
             data: |
               {"awareness": "lsbu+as8d/f0bsd0789fsd07a98fnnuin="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -48,7 +50,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -56,6 +58,7 @@ tests:
             uri: /apps/text/session/push
             data: |
               {"awareness": "0x0800buas8d+f0bsd07/89fsd07a98fnnuin="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -66,7 +69,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -74,6 +77,7 @@ tests:
             uri: /apps/text/public/session/push
             data: |
               {"awareness": "0x0800buas8d+f0bsd07/89fsd07a98fnnuin="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -84,7 +88,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -92,6 +96,7 @@ tests:
             uri: /apps/text/session/1234/push
             data: |
               {"awareness": "lsbu+as8d/f0bsd0789fsd07a98fnnuin="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -102,7 +107,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -110,6 +115,7 @@ tests:
             uri: /apps/text/public/session/1234/push
             data: |
               {"awareness": "lsbu+as8d/f0bsd0789fsd07a98fnnuin="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942432"
@@ -120,7 +126,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -128,6 +134,7 @@ tests:
             uri: /apps/text/session/1234/push
             data: |
               {"awareness": "0x0800buas8d+f0bsd07/89fsd07a98fnnuin="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"
@@ -138,7 +145,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -146,6 +153,7 @@ tests:
             uri: /apps/text/public/session/1234/push
             data: |
               {"awareness": "0x0800buas8d+f0bsd07/89fsd07a98fnnuin="}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "920273"|id "942432"|id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508315.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508315.yaml
@@ -12,7 +12,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -20,6 +20,7 @@ tests:
             uri: /apps/text/attachments
             data: |
               {"shareToken": "lsnus80dfsdf"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"
   - test_title: 9508315-2
@@ -28,7 +29,7 @@ tests:
           input:
             dest_addr: 127.0.0.1
             headers:
-              Host: localhost
+              Host: localhost test agent
               User-Agent: OWASP CRS
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
@@ -37,5 +38,6 @@ tests:
             uri: /apps/text/attachments
             data: |
               {"shareToken": "0x0800nsudf"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508316.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508316.yaml
@@ -12,7 +12,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -22,6 +22,7 @@ tests:
               {"documentId":12,"sessionId":34,"sessionToken":"lrfdsasdf/random","token":null,"filePath":"",
               "steps":["0x0800rs/g/gPGvnfdsc3Q7+oMOfsdfsdafsQGj0cm/B/cCOsdfdsfcZ+6aI+fdtw==","0x0800rs/g/gPGvnfdsc3Q7+oMOfsdfsdafsQGj0cm/B/cCOsdfdsfcZ+6aI+fdtw=="],
               "version":4234,"awareness":"UIBYSAD78+nu9sadfbnd0987safb80ds7abfjbkVBYJABDFhvyib776575"}
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "920273"|id "932236"| id "932250"| id "941100"|id "942210"| id "942432"
@@ -32,7 +33,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -42,6 +43,7 @@ tests:
               {"documentId":12,"sessionId":34,"sessionToken":"lrfdsasdf/random","token":null,"filePath":"",
               "steps":["0x0800rs/g/gPGvnfdsc3Q7+oMOfsdfsdafsQGj0cm/B/cCOsdfdsfcZ+6aI+fdtw==","0x0800rs/g/gPGvnfdsc3Q7+oMOfsdfsdafsQGj0cm/B/cCOsdfdsfcZ+6aI+fdtw=="],
               "version":4234,"awareness":"UIBYSAD78+nu9sadfbnd0987safb80ds7abfjbkVBYJABDFhvyib776575"}
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "920273"|id "932236"| id "932250"| id "941100"|id "942210"| id "942432"| id "942450"
@@ -52,7 +54,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -62,6 +64,7 @@ tests:
               {"documentId":12,"sessionId":34,"sessionToken":"lrfdsasdf/random","token":null,"filePath":"",
               "steps":["0x0800rs/g/gPGvnfdsc3Q7+oMOfsdfsdafsQGj0cm/B/cCOsdfdsfcZ+6aI+fdtw==","0x0800rs/g/gPGvnfdsc3Q7+oMOfsdfsdafsQGj0cm/B/cCOsdfdsfcZ+6aI+fdtw=="],
               "version":4234,"awareness":"UIBYSAD78+nu9sadfbnd0987safb80ds7abfjbkVBYJABDFhvyib776575"}
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "920273"|id "932236"| id "932250"| id "941100"|id "942210"| id "942432"
@@ -72,7 +75,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -82,6 +85,7 @@ tests:
               {"documentId":12,"sessionId":34,"sessionToken":"lrfdsasdf/random","token":null,"filePath":"",
               "steps":["0x0800rs/g/gPGvnfdsc3Q7+oMOfsdfsdafsQGj0cm/B/cCOsdfdsfcZ+6aI+fdtw==","0x0800rs/g/gPGvnfdsc3Q7+oMOfsdfsdafsQGj0cm/B/cCOsdfdsfcZ+6aI+fdtw=="],
               "version":4234,"awareness":"UIBYSAD78+nu9sadfbnd0987safb80ds7abfjbkVBYJABDFhvyib776575"}
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "920273"|id "932236"| id "932250"| id "941100"|id "942210"| id "942432"| id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508330.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508330.yaml
@@ -1,0 +1,23 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508330.yaml
+tests:
+  - test_title: 9508330-1
+    desc: Creating/modifying an calendar from iPhone 
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: text/calendar
+            port: 80
+            method: PUT
+            uri: /remote.php/caldav/calendars/username/stuff/stuff.ics
+          output:
+            no_log_contains: id "920420"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508330.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508330.yaml
@@ -6,7 +6,7 @@ meta:
   name: 9508330.yaml
 tests:
   - test_title: 9508330-1
-    desc: Creating/modifying an calendar from iPhone 
+    desc: Creating/modifying an calendar from iPhone
     stages:
       - stage:
           input:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508330.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508330.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: text/calendar
             port: 80
             method: PUT
             uri: /remote.php/caldav/calendars/username/stuff/stuff.ics
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508337.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508337.yaml
@@ -1,0 +1,62 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Signing into CalDav iPhone"
+  enabled: true
+  name: 9508337.yaml
+tests:
+  - test_title: 9508337-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: text/xml
+            port: 80
+            method: MKCALENDAR
+            uri: /remote.php/dav/calendars/testuser/random/
+            data: |
+              <?xml version="1.0" encoding="UTF-8"?>
+              <B:mkcalendar xmlns:B="urn:ietf:params:xml:ns:caldav">
+                <A:set xmlns:A="DAV:">
+                  <A:prop>
+                    <D:calendar-color xmlns:D="http://apple.com/ns/ical/" symbolic-color="custom">#007AFF</D:calendar-color>
+                    <D:calendar-order xmlns:D="http://apple.com/ns/ical/">1</D:calendar-order>
+                    <B:supported-calendar-component-set>
+                      <B:comp name="VTODO"/>
+                    </B:supported-calendar-component-set>
+                    <A:displayname>DEFAULT_TASK_CALENDAR_NAME</A:displayname>
+                    <B:schedule-calendar-transp>
+                      <B:transparent/>
+                    </B:schedule-calendar-transp>
+                    <B:calendar-timezone>BEGIN:VCALENDAR&#13;
+              VERSION:2.0&#13;
+              CALSCALE:GREGORIAN&#13;
+              BEGIN:VTIMEZONE&#13;
+              TZID:Australia/Melbourne&#13;
+              BEGIN:STANDARD&#13;
+              TZOFFSETFROM:+1100&#13;
+              RRULE:FREQ=YEARLY;BYMONTH=4;BYDAY=1SU&#13;
+              DTSTART:20080406T030000&#13;
+              TZNAME:GMT+10&#13;
+              TZOFFSETTO:+1000&#13;
+              END:STANDARD&#13;
+              BEGIN:DAYLIGHT&#13;
+              TZOFFSETFROM:+1000&#13;
+              RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=1SU&#13;
+              DTSTART:20081005T020000&#13;
+              TZNAME:GMT+11&#13;
+              TZOFFSETTO:+1100&#13;
+              END:DAYLIGHT&#13;
+              END:VTIMEZONE&#13;
+              END:VCALENDAR&#13;
+              </B:calendar-timezone>
+                  </A:prop>
+                </A:set>
+              </B:mkcalendar>
+          output:
+            no_log_contains: |
+              id "911100"| id "942430"| id "942431"| id "942432"| id "942440"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508338.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508338.yaml
@@ -1,0 +1,22 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Dav client scanning for Dav path"
+  enabled: true
+  name: 9508338.yaml
+tests:
+  - test_title: 9508338-1
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: PROPFIND
+            uri: /
+          output:
+            no_log_contains: |
+              id "911100"| id "921110"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508339.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508339.yaml
@@ -13,12 +13,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/xml
             port: 80
             method: MKCOL
             uri: /remote.php/dav/calendars/username/newcalendarname
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "911100"|id "920272"|id "920273"|id "932236" |id "942430" |id "942431" |id "942432"| id "942440"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508362.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508362.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Esad Cetiner"
   description: "Signing into CalDav iPhone"
   enabled: true
-  name: 9508337.yaml
+  name: 9508362.yaml
 tests:
-  - test_title: 9508337-1
+  - test_title: 9508362-1
     stages:
       - stage:
           input:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508362.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508362.yaml
@@ -12,7 +12,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: text/xml
             port: 80
@@ -57,6 +57,7 @@ tests:
                   </A:prop>
                 </A:set>
               </B:mkcalendar>
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "911100"| id "942430"| id "942431"| id "942432"| id "942440"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508400.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508400.yaml
@@ -13,12 +13,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /login
             data: "password=<script>"
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508400-2
@@ -29,12 +30,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /index.php/login
             data: "password=<script>"
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508400-3
@@ -45,12 +47,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /login
             data: "redirect_url=/login/v2/grant?user=Esad%20Cetiner&stateToken=sample-token"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920230|932190|932200|942431|942432)"
@@ -62,12 +65,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /index.php/login
             data: "redirect_url=/login/v2/grant?user=Esad%20Cetiner&stateToken=sample-token"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920230|932190|932200|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508401.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508401.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /login/confirm
             data: |
               {"password": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508401-2
@@ -31,7 +32,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -39,6 +40,7 @@ tests:
             uri: /login/confirm
             data: |
               {"password": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508401-3
@@ -49,7 +51,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -57,6 +59,7 @@ tests:
             uri: /index.php/login/confirm
             data: |
               {"password": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508401-4
@@ -67,7 +70,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -75,5 +78,6 @@ tests:
             uri: /index.php/login/confirm
             data: |
               {"password": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508402.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /login/webauthn/finish
             data: |
               {"data":"{\"id\":\"RanDom__02Data\",\"type\":\"public-key\",\"rawId\":\"FDADG34//fsd88DF=\",\"response\":{\"authenticatorData\":\"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==\",\"clientDataJSON\":\"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==\",\"signature\":\"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=\",\"userHandle\":\"random="}}"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:"920273|932236|942200|942260|942340|942370|942430|942431|942432)"
@@ -32,7 +33,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -40,6 +41,7 @@ tests:
             uri: /index.php/login/webauthn/finish
             data: |
               {"data":"{\"id\":\"RanDom__02Data\",\"type\":\"public-key\",\"rawId\":\"FDADG34//fsd88DF=\",\"response\":{\"authenticatorData\":\"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==\",\"clientDataJSON\":\"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==\",\"signature\":\"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=\",\"userHandle\":\"random="}}"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:"920273|932236|942200|942260|942340|942370|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508403.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508403.yaml
@@ -13,12 +13,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /login/v2/grant
             data: "stateToken=0x0800"
+            version: HTTP/1.1
           output:
             no_log_contains: id "942450"
   - test_title: 9508403-2
@@ -29,12 +30,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /login/v2/grant
             data: "stateToken=lsbsdf7ASD9gh79d"
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"
   - test_title: 9508403-3
@@ -45,12 +47,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
             data: "stateToken=0x0800"
+            version: HTTP/1.1
           output:
             no_log_contains: id "942450"
   - test_title: 9508403-4
@@ -61,11 +64,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
             data: "stateToken=lsbsdf7ASD9gh79d"
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508411.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508411.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /lostpassword/set/random/username
             data: |
               {"password": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508411-2
@@ -31,7 +32,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -39,5 +40,6 @@ tests:
             uri: /index.php/lostpassword/set/random/username
             data: |
               {"password": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508420.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508420.yaml
@@ -18,13 +18,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login
             data: "requesttoken=lds%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -38,13 +39,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -58,13 +60,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -78,13 +81,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login
             data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -98,13 +102,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login
             data: "requesttoken=lds%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -118,13 +123,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -138,13 +144,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -158,13 +165,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login
             data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -178,13 +186,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /logout
             data: "requesttoken=lds%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -198,13 +207,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /logout
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -218,13 +228,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /logout
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -238,13 +249,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /logout
             data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -258,13 +270,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/logout
             data: "requesttoken=lds%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -278,13 +291,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/logout
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -298,13 +312,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/logout
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -318,13 +333,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/logout
             data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -338,13 +354,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
             data: "requesttoken=lds%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -358,13 +375,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -378,13 +396,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -398,13 +417,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /s/share-id/authenticate/showShare
             data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -418,13 +438,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
             data: "requesttoken=lds%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -438,13 +459,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -458,13 +480,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -478,13 +501,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/s/share-id/authenticate/showShare
             data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -498,13 +522,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login/v2/grant
             data: "requesttoken=lds%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -518,13 +543,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login/v2/grant
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -538,13 +564,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login/v2/grant
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -558,13 +585,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /login/v2/grant
             data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -578,13 +606,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
             data: "requesttoken=lds%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -598,13 +627,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -618,13 +648,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
             data: "requesttoken=lss%3A978%2B%2Fdfdsa"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"
@@ -638,13 +669,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /index.php/login/v2/grant
             data: "requesttoken=0x800%3Afds%2B%2Fdsfsda"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942100|942120|942432|942450)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508511.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508511.yaml
@@ -13,10 +13,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: GET
             uri: /example.css?v=lsrandom-52
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508530.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508530.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/octet-stream
             port: 80
             method: POST
             uri: /index.php/apps/richdocuments/wopi/files/random_instanceid/contents
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508533.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508533.yaml
@@ -13,12 +13,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /index.php/apps/richdocuments/wopi/files/random_instanceid/contents
             data: "access_token=lsrandom03843"
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"
   - test_title: 9508533-2
@@ -29,12 +30,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /index.php/apps/richdocuments/wopi/files/random_instanceid
             data: "access_token=lsrandom03843"
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"
   - test_title: 9508533-3
@@ -45,12 +47,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /index.php/apps/richdocuments/wopi/files/random_instanceid/contents
             data: "access_token=0x0800random45"
+            version: HTTP/1.1
           output:
             no_log_contains: id "942450"
   - test_title: 9508533-4
@@ -61,11 +64,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /index.php/apps/richdocuments/wopi/files/random_instanceid
             data: "access_token=0x0800random45"
+            version: HTTP/1.1
           output:
             no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508540.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508540.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: text/plain
             port: 80
             method: POST
             uri: /apps/richdocumentscode/proxy.php
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508541.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508541.yaml
@@ -13,12 +13,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: text/plain
             port: 80
             method: POST
             uri: /apps/richdocumentscode/proxy.php
             data: "buy_product=https://nextcloud.com/pricing"
+            version: HTTP/1.1
           output:
             no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508550.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508550.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: text/plain
             port: 80
             method: POST
             uri: /browser/random/cool.html
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508551.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508551.yaml
@@ -13,12 +13,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: text/plain
             port: 80
             method: POST
             uri: /browser/random/cool.html
             data: "buy_product=https://nextcloud.com/pricing"
+            version: HTTP/1.1
           output:
             no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508553.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508553.yaml
@@ -13,12 +13,13 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /browser/random/cool.html
             data: "access_token=lsrandom03843"
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"
   - test_title: 9508553-2
@@ -29,11 +30,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: POST
             uri: /browser/random/cool.html
             data: "access_token=lsrandom03843"
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508624.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /settings/api/personal/webauthn/registration
             data: |
               {"data":"{\"id\":\"RanDom__02Data\",\"type\":\"public-key\",\"rawId\":\"FDADG34//fsd88DF=\",\"response\":{\"authenticatorData\":\"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==\",\"clientDataJSON\":\"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==\",\"signature\":\"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=\",\"userHandle\":\"random=\"}}"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942200|942260|942340|942370|942430|942431|942432)"
@@ -32,7 +33,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -40,6 +41,7 @@ tests:
             uri: /settings/api/personal/webauthn/registration
             data: |
               {"data":"{\"id\":\"RanDom__02Data\",\"type\":\"public-key\",\"rawId\":\"FDADG34//fsd88DF=\",\"response\":{\"authenticatorData\":\"3/fds+dsf79dDAF/SQ+sdfaf89sDFS==\",\"clientDataJSON\":\"7sdfybsdfbyubYUFDBVASUBYFASD7687gdsfb==\",\"signature\":\"dsyuifabHBJDAF989+sfddsfDFKJ6678+fsd676JKG+S8dg=\",\"userHandle\":\"random=\"}}"}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920273|932236|942200|942260|942340|942370|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508628.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508628.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /apps/oauth2/clients/42
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508628-2
@@ -28,11 +29,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /apps/oauth2/clients
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508628-3
@@ -43,7 +45,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -51,6 +53,7 @@ tests:
             uri: /apps/oauth2/clients/42
             data: |
               {"redirectUri": "https://example.com/"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "931130"
   - test_title: 9508628-4
@@ -61,7 +64,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -69,5 +72,6 @@ tests:
             uri: /apps/oauth2/clients
             data: |
               {"redirectUri": "https://example.com/"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508629.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508629.yaml
@@ -13,10 +13,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /ocs/v2.php/apps/files_retention/api/v2/retentions/42
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508630.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508630.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /apps/mail/api/integration/google
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508630-2
@@ -28,10 +29,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /apps/mail/api/integration/microsoft
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508631.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508631.yaml
@@ -17,6 +17,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               data: "lastReqId=lsbusydifb08"
             port: 80
+            version: HTTP/1.1
             method: POST
             uri: /apps/logreader/poll
           output:
@@ -33,6 +34,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               data: "lastReqId=0x0800dasf86gm"
             port: 80
+            version: HTTP/1.1
             method: POST
             uri: /apps/logreader/poll
           output:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508631.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508631.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               data: "lastReqId=lsbusydifb08"
             port: 80
@@ -29,7 +29,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               data: "lastReqId=0x0800dasf86gm"
             port: 80
@@ -45,11 +45,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: GET
             uri: /apps/logreader/api/poll?lastReqId=lsbusydifb08
+            version: HTTP/1.1
           output:
             no_log_contains: id "932236"
   - test_title: 9508631-4
@@ -60,10 +61,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: GET
             uri: /apps/logreader/api/poll?lastReqId=0x0800dasf86gm
+            version: HTTP/1.1
           output:
             no_log_contains: id "942450"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508632.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508632.yaml
@@ -13,10 +13,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /apps/twofactor_email/settings/disable
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508633.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508633.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,5 +21,6 @@ tests:
             uri: /index.php/apps/richdocuments/ajax/admin.php
             data: |
               {"wopi_url": "https://example.com/"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508634.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508634.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /apps/logreader/api/settings
             data: |
               { "settingsKey": "liveLog","settingsValue": false }
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508634-2
@@ -31,7 +32,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -39,5 +40,6 @@ tests:
             uri: /apps/logreader/api/settings
             data: |
               { "settingsKey": "liveLog","settingsValue": true }
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508635.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508635.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,5 +21,6 @@ tests:
             uri: /apps/logreader/api/settings
             data: |
               { "setting":"defaultApps","value":["files","dashboard"] }
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508636.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508636.yaml
@@ -13,10 +13,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /ocs/v2.php/apps/dav/api/v1/outOfOffice/username
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508637.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508637.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PROPPATCH
@@ -54,6 +54,7 @@ tests:
                                 </x0:prop>
                           </x0:set>
                         </x0:propertyupdate>
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "(?:911100|932236|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508810.yaml
@@ -15,7 +15,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -25,6 +25,7 @@ tests:
               {"description:": "This is a description.
 
               Use this [link](https://github.com/microsoft/vscode/issues?page=3&q=is%3Aissue+is%3Aopen)."}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"
@@ -36,11 +37,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /apps/deck/cards/1/unassign
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"
@@ -54,7 +56,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -62,6 +64,7 @@ tests:
             uri: /apps/deck/cards/1
             data: |
               {"data":{"id":16,"title":"Title","description":"","stackId":11,"type":"plain","lastModified":1708032296,"lastEditor":null,"createdAt":1708013998,"labels":[{"id":9,"title":"Terminé","color":"31CC7C","boardId":3,"cardId":null,"lastModified":0,"ETag":"cfcd208495d565ef66e7dff9f98764da"}],"owner":{"primaryKey":"mivek","uid":"mivek","displayname":"mivek","type":0},"order":2,"duedate":"2024-02-15T23:00:00.000Z","deletedAt":0,"boardId":3}}
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "911100"|id "932200"|id "933210"|id "942200"|id "942260"|id "942370"|id "942430"|id "942440"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508830.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508830.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /apps/dashboard/statuses
             data: |
               { "statuses":"{\"weather\":true,\"status\":true}" }
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:932240|942260|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508850.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508850.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /ocs/v2.php/cloud/users/johndoe/disable
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508850-2
@@ -28,11 +29,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /ocs/v2.php/cloud/users/johndoe/enable
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508850-3
@@ -43,11 +45,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /ocs/v2.php/cloud/users/johndoe
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508850-4
@@ -58,10 +61,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
             uri: /ocs/v2.php/cloud/groups/accountants
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508852.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508852.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,5 +21,6 @@ tests:
             data: |
               {"value": "https://example.com/"}
             uri: /ocs/v2.php/cloud/users/
+            version: HTTP/1.1
           output:
             no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508854.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508854.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /apps/photos/api/v1/config/croppedLayout
             data: |
               {"value":"false"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508854-2
@@ -31,7 +32,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -39,5 +40,6 @@ tests:
             uri: /apps/photos/api/v1/config/croppedLayout
             data: |
               {"value":"true"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508880.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508880.yaml
@@ -13,13 +13,14 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/x-www-form-urlencoded
             port: 80
             method: POST
             uri: /ocs/v2.php/references/resolve
             data: "reference=https://www.jaycar.com.au/raspberry-pi-3-switchmode-power-supply-5-1v-2-5a-with-usb-micro-b/p/MP3536?pos=1&queryId=0a9ebf34f466c42c586d9561f4ac20d2&sort=relevance&searchText=2.5a%205v%20micro%20usb"
+            version: HTTP/1.1
           output:
             no_log_contains: |-
               id "(?:920230|931130|932200|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508881.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508881.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /ocs/v2.php/references/provider/files
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508881-2
@@ -28,10 +29,11 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: PUT
             uri: /ocs/v2.php/references/provider/any-link
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508955.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508955.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: text/plain;charset=UTF-8
             port: 80
@@ -43,5 +43,6 @@ tests:
               	  <oc:share-types />
                 </d:prop>
               </d:propfind>
+            version: HTTP/1.1
           output:
             no_log_contains: id "920420"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508961.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508961.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,6 +21,7 @@ tests:
             uri: /apps/files/api/v1/config/crop_image_previews
             data: |
               { "value":true }
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508961-2
@@ -31,7 +32,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -39,6 +40,7 @@ tests:
             uri: /apps/files/api/v1/config/grid_view
             data: |
               { "value":true }
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508961-3
@@ -49,7 +51,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -57,6 +59,7 @@ tests:
             uri: /apps/files/api/v1/config/show_hidden
             data: |
               { "value":true }
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508961-4
@@ -67,7 +70,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -75,6 +78,7 @@ tests:
             uri: /apps/files/api/v1/config/sort_favorites_first
             data: |
               { "value":true }
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"
   - test_title: 9508961-5
@@ -85,7 +89,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -93,5 +97,6 @@ tests:
             uri: /apps/files/api/v1/config/sort_folders_first
             data: |
               { "value":true }
+            version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508973.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508973.yaml
@@ -13,11 +13,12 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: GET
             uri: /apps/mail/proxy?src=https://go.netacad.com/rs/059-VFZ-834/images/ezgif.com-animated-gif-maker%281%29.gif
+            version: HTTP/1.1
           output:
             no_log_contains: |
               id "(?:920230|920273|931130|942421|942430|942431|942432)"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508978.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508978.yaml
@@ -13,7 +13,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -21,5 +21,6 @@ tests:
             uri: /apps/mail/api/messages/1/flags
             data: |
               {"flags": {"$notjunk": 1}}
+            version: HTTP/1.1
           output:
             no_log_contains: id "942290"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508991.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508991.yaml
@@ -17,7 +17,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -25,6 +25,7 @@ tests:
             uri: /apps/mail/api/drafts/1
             data: |
               {"body": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-2
@@ -39,7 +40,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -47,6 +48,7 @@ tests:
             uri: /apps/mail/api/drafts/1
             data: |
               {"data":{"body":{"value": "<script>"}}}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-3
@@ -61,7 +63,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -69,6 +71,7 @@ tests:
             uri: /apps/mail/api/drafts/1
             data: |
               {"data":{"editorBody": "<script>"}}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-4
@@ -83,7 +86,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -91,6 +94,7 @@ tests:
             uri: /apps/mail/api/drafts/1
             data: |
               {"editorBody": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-5
@@ -105,7 +109,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -113,6 +117,7 @@ tests:
             uri: /apps/mail/api/drafts/{id}
             data: |
               {"body": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-6
@@ -127,7 +132,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -135,6 +140,7 @@ tests:
             uri: /apps/mail/api/drafts/{id}
             data: |
               {"data":{"body":{"value": "<script>"}}}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-7
@@ -149,7 +155,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -157,6 +163,7 @@ tests:
             uri: /apps/mail/api/drafts/{id}
             data: |
               {"data":{"editorBody": "<script>"}}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-8
@@ -171,7 +178,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -179,6 +186,7 @@ tests:
             uri: /apps/mail/api/drafts/{id}
             data: |
               {"editorBody": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-9
@@ -192,7 +200,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -200,6 +208,7 @@ tests:
             uri: /apps/mail/api/drafts/{id}
             data: |
               {"subject": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508991-10
@@ -213,7 +222,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -221,5 +230,6 @@ tests:
             uri: /apps/mail/api/drafts/1
             data: |
               {"subject": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508992.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508992.yaml
@@ -16,7 +16,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -24,6 +24,7 @@ tests:
             uri: /apps/mail/api/outbox/1
             data: |
               {"editorBody": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-2
@@ -37,7 +38,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -45,6 +46,7 @@ tests:
             uri: /apps/mail/api/outbox/1
             data: |
               {"body": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-3
@@ -57,7 +59,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -65,6 +67,7 @@ tests:
             uri: /apps/mail/api/outbox/1
             data: |
               {"subject": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-4
@@ -78,7 +81,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -86,6 +89,7 @@ tests:
             uri: /apps/mail/api/outbox/from-draft/1
             data: |
               {"editorBody": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-5
@@ -99,7 +103,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -107,6 +111,7 @@ tests:
             uri: /apps/mail/api/outbox/from-draft/1
             data: |
               {"body": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"
   - test_title: 9508992-6
@@ -119,7 +124,7 @@ tests:
             dest_addr: 127.0.0.1
             headers:
               Host: localhost
-              User-Agent: OWASP CRS
+              User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
@@ -127,5 +132,6 @@ tests:
             uri: /apps/mail/api/outbox/from-draft/1
             data: |
               {"subject": "<script>"}
+            version: HTTP/1.1
           output:
             no_log_contains: id "941101"


### PR DESCRIPTION
I've tested caldav and cardav on iPhone and found a few false positives. I don't personally own/use any apple product so I can't guarantee that all false positives are gone, just the ones that I found.

tested on iPhone 8 with iOS 15.6.1

may fix #63 