### PR TITLE
fix: requesting a static file at pl-2

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -998,7 +998,12 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users(?:/[^/]+)?$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.value"
 
+#
+# [ General rule exclusions ]
+#
+
 # Fix Nextcloud Cookie FPs
+# Fix false positives with static files version
 # Operator @unconditionalMatch is used instead of a SecAction because of a bug
 # in ModSecurity v3 which prevents SecActions to be removed using ctl action.
 SecRule REQUEST_FILENAME "@unconditionalMatch" \
@@ -1008,6 +1013,7 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
+    ctl:ruleRemoveTargetById=932236;ARGS:v,\
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:nc_session_id,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES:nc_session_id,\
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:nc_token,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1111,7 +1111,6 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users(?:/[^/]+)?$" \
 #
 
 # Fix Nextcloud Cookie FPs
-# Fix false positives with static files version
 # Operator @unconditionalMatch is used instead of a SecAction because of a bug
 # in ModSecurity v3 which prevents SecActions to be removed using ctl action.
 SecRule REQUEST_FILENAME "@unconditionalMatch" \
@@ -1121,7 +1120,6 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
-    ctl:ruleRemoveTargetById=932236;ARGS:v,\
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:nc_session_id,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES:nc_session_id,\
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:nc_token,\
@@ -1129,6 +1127,16 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     ctl:ruleRemoveTargetById=932236;REQUEST_COOKIES:oc_sessionPassphrase,\
     ctl:ruleRemoveTargetById=942210;REQUEST_COOKIES:oc_sessionPassphrase,\
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES:oc_sessionPassphrase"
+
+# Fix false positives with static files
+SecRule REQUEST_FILENAME "@rx \.(?:avif|bmp|brotli|bvr|css|eot|gif|gz|ico|jpeg|jpg|map|m?js|mp[34]|otf|png|svg|swf|ts|ttf|txt|wav|webp|woff2?)$" \
+    "id:9508511,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
+    ctl:ruleRemoveTargetById=932236;ARGS:v"
 
 #
 # [ Nextcloud Setup ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1129,7 +1129,7 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     ctl:ruleRemoveTargetById=942450;REQUEST_COOKIES:oc_sessionPassphrase"
 
 # Fix false positives with static files
-SecRule REQUEST_FILENAME "@rx \.(?:avif|bmp|brotli|bvr|css|eot|gif|gz|ico|jpeg|jpg|map|m?js|mp[34]|otf|png|svg|swf|ts|ttf|txt|wav|webp|woff2?)$" \
+SecRule REQUEST_FILENAME "@rx (?i)\.(?:avif|bmp|brotli|bvr|css|eot|gif|gz|ico|jpeg|jpg|map|m?js|mp[34]|otf|png|svg|swf|ts|ttf|txt|wav|webp|woff2?)$" \
     "id:9508511,\
     phase:1,\
     pass,\

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508510.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508510.yaml
@@ -1,0 +1,22 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508510.yaml
+tests:
+  - test_title: 9508510-1
+    desc: requesting a static file
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: GET
+            uri: /example.css?v=lsrandom-52
+          output:
+            no_log_contains: id "932236"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508511.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508511.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508510.yaml
+  name: 9508511.yaml
 tests:
-  - test_title: 9508510-1
+  - test_title: 9508511-1
     desc: requesting a static file
     stages:
       - stage:


### PR DESCRIPTION
Fixes false positives when requesting a static file at pl-2 or higher with the ver argument. I haven't done any character whitelisting since this is just used for static files, there's nothing to attack.