### PR TITLE
fix: .well-known/webdav fp

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -11,6 +11,7 @@
 - [ignatiev](https://github.com/ignatiev)
 - [Joost de Keijzer](https://github.com/joostdekeijzer)
 - [Max Leske](https://github.com/theseion)
+- [Matus](https://github.com/yeapguy)
 - [pyllyukko](https://github.com/pyllyukko)
 - [Chaim Sanders](https://github.com/csanders-git)
 - [Federico G. Schwindt](https://github.com/fgsch)

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1327,6 +1327,16 @@ SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
     ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
 
+# Also for WebDAV (not listed on Security & setup warnings, but needed)
+SecRule REQUEST_FILENAME "@contains /.well-known/webdav" \
+    "id:9508616,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
+
 # Administration --> Sharing --> Federated cloud sharing
 # When trying to delete a trusted server
 SecRule REQUEST_FILENAME "@contains /apps/federation/trusted-servers/" \


### PR DESCRIPTION
Adds a rule similar to 9508602 & 9508603 to prevent blocking discovering WebDAV on /.well-known:

```
ModSecurity: Warning. Matched "Operator `Within' with parameter `GET HEAD POST OPTIONS PUT' against variable `REQUEST_METHOD' (Value: `PROPFIND' ) [file "/usr/local/nginx/conf/conf.d/include/coreruleset/rules/REQUEST-911-METHOD-ENFORCEMENT.conf"] [line "28"] [id "911100"] [rev ""] [msg "Method is not allowed by policy"] [data "PROPFIND"] [severity "2"] [ver "OWASP_CRS/4.0.0"] [maturity "0"] [accuracy "0"] [tag "application-multi"] [tag "language-multi"] [tag "platform-multi"] [tag "attack-generic"] [tag "paranoia-level/1"] [tag "OWASP_CRS"] [tag "capec/1000/210/272/220/274"] [tag "PCI/12.1"] [hostname "172.19.0.7"] [uri "/.well-known/webdav/xxx/"] [unique_id "171119327475.703982"] [ref "v0,8"]
```