### PR TITLE
fix: fp regression with xml content

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -868,11 +868,11 @@ SecRule REQUEST_FILENAME "@rx ^/remote\.php/dav/calendars/[^/]+/[^/]+/?$" \
         "t:none,\
         ctl:ruleRemoveTargetById=920272;REQUEST_BODY,\
         ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
-        ctl:ruleRemoveTargetById=932236;XML,\
-        ctl:ruleRemoveTargetById=942430;XML,\
-        ctl:ruleRemoveTargetById=942431;XML,\
-        ctl:ruleRemoveTargetById=942432;XML,\
-        ctl:ruleRemoveTargetById=942440;XML"
+        ctl:ruleRemoveTargetById=932236;XML:/*,\
+        ctl:ruleRemoveTargetById=942430;XML:/*,\
+        ctl:ruleRemoveTargetById=942431;XML:/*,\
+        ctl:ruleRemoveTargetById=942432;XML:/*,\
+        ctl:ruleRemoveTargetById=942440;XML:/*"
 
 # Enabling/disabling "Enable birthday calendar setting
 # Deleting an calendar group
@@ -919,10 +919,10 @@ SecRule REQUEST_FILENAME "@rx /remote.php/dav/calendars/[^/]+/[^/]+/$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
-    ctl:ruleRemoveTargetById=942430;XML,\
-    ctl:ruleRemoveTargetById=942431;XML,\
-    ctl:ruleRemoveTargetById=942432;XML,\
-    ctl:ruleRemoveTargetById=942440;XML,\
+    ctl:ruleRemoveTargetById=942430;XML:/*,\
+    ctl:ruleRemoveTargetById=942431;XML:/*,\
+    ctl:ruleRemoveTargetById=942432;XML:/*,\
+    ctl:ruleRemoveTargetById=942440;XML:/*,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} MKCALENDAR'"
 
 #
@@ -1774,10 +1774,10 @@ SecRule REQUEST_FILENAME "@rx /remote.php/dav/calendars/[^/]+/inbox$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.1.0',\
-    ctl:ruleRemoveTargetById=932236;XML,\
-    ctl:ruleRemoveTargetById=942430;XML,\
-    ctl:ruleRemoveTargetById=942431;XML,\
-    ctl:ruleRemoveTargetById=942432;XML"
+    ctl:ruleRemoveTargetById=932236;XML:/*,\
+    ctl:ruleRemoveTargetById=942430;XML:/*,\
+    ctl:ruleRemoveTargetById=942431;XML:/*,\
+    ctl:ruleRemoveTargetById=942432;XML:/*"
 
 #
 # [ Notifications ]


### PR DESCRIPTION
A previous pull request removed XPath XML, this has caused a regression with XML content and introduced some new false positives. This PR reverts those changes