### PR TITLE
fix: use case insensitivity for public shares when entering passwords

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -331,7 +331,8 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/trashbin/[^/]+/trash/" \
             setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
 # Entering a password for a password protected share
-SecRule REQUEST_FILENAME "@rx /s/[^/]+/authenticate/showShare$" \
+# Some Nextcloud versions have inconsistent case sensitivity
+SecRule REQUEST_FILENAME "@rx (?i)/s/[^/]+/authenticate/showshare$" \
     "id:9508171,\
     phase:1,\
     pass,\

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508171.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508171.yaml
@@ -6,7 +6,7 @@ meta:
   name: 9508171.yaml
 tests:
   - test_title: 9508171-1
-    desc: Entering password on a public share
+    desc: Entering password on a public share (Nextcloud changed the case on this endpoint, tested on 29.0.3)
     stages:
       - stage:
           input:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508171.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508171.yaml
@@ -1,0 +1,45 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508171.yaml
+tests:
+  - test_title: 9508171-1
+    desc: Entering password on a public share
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: POST
+            uri: /s/random/authenticate/showshare
+            data: |
+              requesttoken=random&password=%3Cscript%3E&sharingToken=random&sharingType=3
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "941101"
+  - test_title: 9508171-2
+    desc: Entering password on a public share
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: POST
+            uri: /s/random/authenticate/showShare
+            data: |
+              requesttoken=random&password=%3Cscript%3E&sharingToken=random&sharingType=3
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "941101"


### PR DESCRIPTION
Nextcloud has recently renamed the endpoint for entering passwords in public shares from ``/s/random/authenticate/showShare`` to ``/s/random/authenticate/showshare`` causing the rule that handles false positives with passwords to no longer match. This PR makes that rule case insensitive.