### PR TITLE
refactor: overhaul and cleanup rule exclusions for settings

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1773,7 +1773,7 @@ SecRule REQUEST_FILENAME "@rx /apps/bruteforcesettings/ipwhitelist/[0-9]+$" \
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
 # Administration Settings --> Theming --> Advanced Options
-# Adding links foir legal notices and privacy policies
+# Adding links for legal notices and privacy policies
 SecRule REQUEST_FILENAME "@endsWith /apps/theming/ajax/updateStylesheet" \
     "id:9508648,\
     phase:1,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -922,7 +922,7 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/calendars/[^/]+/trashbin/objects/
 
 # Creating new calendar groups in web GUI
 # The / at the end is sometimes not included
-SecRule REQUEST_FILENAME "@rx ^/remote\.php/dav/calendars/[^/]+/[^/]+/?$" \
+SecRule REQUEST_FILENAME "@rx /remote\.php/dav/calendars/[^/]+/[^/]+/?$" \
     "id:9508339,\
     phase:1,\
     pass,\
@@ -1218,6 +1218,16 @@ SecRule REQUEST_FILENAME "@rx (?i)\.(?:avif|bmp|brotli|bvr|css|eot|gif|gz|ico|jp
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
     ctl:ruleRemoveTargetById=932236;ARGS:v"
 
+# While going through the first run setup wizard
+SecRule REQUEST_FILENAME "@endsWith /apps/firstrunwizard/wizard" \
+    "id:9508512,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
 #
 # [ Nextcloud Setup ]
 #
@@ -1430,170 +1440,67 @@ SecRule REQUEST_FILENAME "@rx /browser/[^/]+/cool\.html$" \
         ctl:ruleRemoveTargetById=942450;ARGS:access_token"
 
 #
-# [ Settings pages ]
+# [ Personal Settings ]
 #
-# This removes checks on multiple settings pages
 
-# Personal: Security
-
-# Fixes deletion and allow/disallow of filesystem access for auth tokens
+# Personal Settings --> Security --> Devices & sessions
+# Creating/revoking authentication tokens/sessions
 SecRule REQUEST_FILENAME "@rx /settings/personal/authtokens/[0-9]+$" \
+    "id:9508600,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
+
+# Personal Settings --> Security --> Passwordless Authentication
+# When trying to remove a WebAuthn device
+SecRule REQUEST_FILENAME "@rx /settings/api/personal/webauthn/registration/[0-9]+$" \
     "id:9508601,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
-
-# When trying to remove a WebAuthn device
-SecRule REQUEST_FILENAME "@rx /settings/api/personal/webauthn/registration/[0-9]+$" \
-    "id:9508606,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
-# While going through the first run setup wizard
-SecRule REQUEST_FILENAME "@endsWith /apps/firstrunwizard/wizard" \
-    "id:9508607,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# When trying to update Personal --> Sharing --> Sharing --> Accept user and groups shares by default
+# Personal Settings --> Sharing --> Sharing --> Accept user and groups shares by default
+# When trying to update
 SecRule REQUEST_FILENAME "@rx /apps/files_sharing/settings/(?:defaultAccept|shareFolder)$" \
-    "id:9508608,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
-
-# When trying to delete profile picture in Personal --> Personal info
-SecRule REQUEST_FILENAME "@endsWith /avatar" \
-    "id:9508611,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# When trying to delete users with data access(Personal --> Privacy --> Who has access to your data?)
-SecRule REQUEST_FILENAME "@rx /apps/privacy/api/admins/[0-9]+$" \
-    "id:9508614,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# Personal --> Availability
-# When trying to "Automatically set user status to Do no disturb"
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9]+/config/users/dav/user_status_automation" \
-    "id:9508615,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-
-# Administration: Overview
-
-# Fixed "Security & setup warnings" test
-SecRule REQUEST_FILENAME "@contains /.well-known/caldav" \
     "id:9508602,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
 
-SecRule REQUEST_FILENAME "@contains /.well-known/carddav" \
+# Personal Settings --> Personal Info --> Profile Picture
+# Removing a custom profile picture
+SecRule REQUEST_FILENAME "@endsWith /avatar" \
     "id:9508603,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
-
-# Also for WebDAV (not listed on Security & setup warnings, but needed)
-SecRule REQUEST_FILENAME "@contains /.well-known/webdav" \
-    "id:9508616,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
-
-# Administration --> Sharing --> Federated cloud sharing
-# When trying to delete a trusted server
-SecRule REQUEST_FILENAME "@contains /apps/federation/trusted-servers/" \
-    "id:9508609,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
-# When trying to change cron method in Administration --> Basic settings --> Background jobs
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9]+/config/apps/core/cronErrors" \
-    "id:9508612,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# When trying to enforce Two-Factor Authentication for a group(Administration --> Security --> Two-Factor Authentication)
-SecRule REQUEST_FILENAME "@contains /settings/api/admin/twofactorauth" \
-    "id:9508613,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# When trying to change log levels and live update in (Administration --> Logging)
-SecRule REQUEST_FILENAME "@rx /apps/logreader/(?:live|levels)" \
-    "id:9508610,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# Appearance and accessibility
-
-# Enabling any default theme requires the PUT method.
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/theming/api/v[0-9]+/theme/.*?/enable" \
+# Personal Settings --> Availability
+# Disabling "Automatically set user status to Do no disturb" option
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9\.]+\.php/apps/provisioning_api/api/v[0-9\.]+/config/users/dav/user_status_automation$" \
     "id:9508604,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
-# When trying to enable keyboard shortcuts
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9]+/config/users/theming/shortcuts_disabled" \
+# Personal Settings --> Appearance and Accessibility --> Dyslexia font
+# Disabling Dyslexia font
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/theming/api/v[0-9]/theme/opendyslexic$" \
     "id:9508605,\
     phase:1,\
     pass,\
@@ -1602,9 +1509,32 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9]
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
+# Personal Settings --> Appearance and Accessibility
+# Enabling any default theme requires the PUT method.
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/theming/api/v[0-9]+/theme/.*?/enable" \
+    "id:9508606,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Personal Settings --> Appearance and Accessibility
+# When trying to enable keyboard shortcuts
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9]+/config/users/theming/shortcuts_disabled" \
+    "id:9508607,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+# Personal Settings --> Appearance and Accessibility --> Background
 # Disabling background
 SecRule REQUEST_FILENAME "@endsWith /apps/theming/background/custom" \
-    "id:9508617,\
+    "id:9508608,\
     phase:1,\
     pass,\
     t:none,\
@@ -1612,60 +1542,10 @@ SecRule REQUEST_FILENAME "@endsWith /apps/theming/background/custom" \
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
-# When disabling settings under Settings --> Availability
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/provisioning_api/api/v[0-9]/config/users/dav/user_status_automation$" \
-    "id:9508619,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# When configurating an SMTP server under Administration --> Basic Settings --> Email Server
-SecRule REQUEST_FILENAME "@endsWith /settings/admin/mailsettings/credentials" \
-    "id:9508620,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:mail_smtppassword"
-
-# When removing whitelisted IPs under Administration --> Security --> Brute Force IP whitelsit
-SecRule REQUEST_FILENAME "@rx /apps/bruteforcesettings/ipwhitelist/[0-9]+$" \
-    "id:9508621,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# When adding legal notices and privacy policy under Administration --> Theming --> Advanced Options
-SecRule REQUEST_FILENAME "@endsWith /apps/theming/ajax/updateStylesheet" \
-    "id:9508622,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    ctl:ruleRemoveTargetById=931130;ARGS:value,\
-    ctl:ruleRemoveTargetById=931130;ARGS:json.value"
-
-# Disabling Dyslexia font under Settings --> Appearance and Accessibility --> Dyslexia font
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/theming/api/v[0-9]/theme/opendyslexic$" \
-    "id:9508623,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# Registering webauthn devices under Settings --> Personal --> Security --> Passwordless Authentication
+# Personal Settings --> Security --> Passwordless Authentication
+# Registering webauthn devices
 SecRule REQUEST_FILENAME "@endsWith /settings/api/personal/webauthn/registration" \
-    "id:9508624,\
+    "id:9508609,\
     phase:1,\
     pass,\
     t:none,\
@@ -1679,9 +1559,10 @@ SecRule REQUEST_FILENAME "@endsWith /settings/api/personal/webauthn/registration
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:data,\
     ctl:ruleRemoveTargetByTag=attack-sqli;ARGS:json.data"
 
-# When a user is changing their password under settings --> Personal --> Security --> Password
+# Personal Settings --> Security --> Password
+# When a user is changing their password under
 SecRule REQUEST_FILENAME "@endsWith /settings/personal/changepassword" \
-    "id:9508625,\
+    "id:9508610,\
     phase:1,\
     pass,\
     t:none,\
@@ -1692,129 +1573,10 @@ SecRule REQUEST_FILENAME "@endsWith /settings/personal/changepassword" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.oldpassword,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.newpassword"
 
-# Validating password against password policy
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/password_policy/api/v[0-9]/validate$" \
-    "id:9508626,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password"
-
-# Adjusting the amount of cores used for AI facial recognition under Settings --> Administration --> Recognize --> CPU Cores
-# This rule doesn't try to enumerate all endpoints and uses a contains instead, there's simply WAY too many to enumerate.
-# If you try, then the regex becomes unreadable and painful to work with.
-SecRule REQUEST_FILENAME "@contains /apps/recognize/admin/settings/" \
-    "id:9508627,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    ctl:ruleRemoveTargetById=932160;ARGS:value,\
-    ctl:ruleRemoveTargetById=932160;ARGS:json.value,\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# When configuring OAuth 2 clients under Administration --> Security --> OAuth 2.0 clients
-# DELETE - Deleting an OAuth client
-SecRule REQUEST_FILENAME "@rx /apps/oauth2/clients(?:/[0-9]+)?$" \
-    "id:9508628,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    ctl:ruleRemoveTargetById=931130;ARGS:redirectUri,\
-    ctl:ruleRemoveTargetById=932236;ARGS:name,\
-    ctl:ruleRemoveTargetById=931130;ARGS:json.redirectUri,\
-    ctl:ruleRemoveTargetById=932236;ARGS:json.name,\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# Disabling automatic deletion of a tag type under Administration --> Flow --> File retention & automatic deletion
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/files_retention/api/v[0-9]/retentions/[0-9]+$" \
-    "id:9508629,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# When enabling / disabling Microsoft / Gmail email integration via OAuth 2 under Settings --> Administration 
-# --> Groupware --> Mail app --> Microsoft integration
-SecRule REQUEST_FILENAME "@rx /apps/mail/api/integration/(?:google|microsoft)$" \
-    "id:9508630,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# Viewing Nextcloud logs
-# Settings --> Administration --> Log Reader
-SecRule REQUEST_FILENAME "@rx /apps/logreader(?:/api)?/poll$" \
-    "id:9508631,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    chain"
-    SecRule ARGS:lastReqId "@rx (?i)^[a-z0-9]+$" \
-        "t:none,\
-        ctl:ruleRemoveTargetById=932236;ARGS:lastReqId,\
-        ctl:ruleRemoveTargetById=942450;ARGS:lastReqId"
-
-# When disabling 2FA email under Settings --> Personal --> Security
-SecRule REQUEST_FILENAME "@endsWith /apps/twofactor_email/settings/disable" \
-    "id:9508632,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
-
-# Configuring WOPI URL for dedicated Collabora Server
-SecRule REQUEST_FILENAME "@endsWith /index.php/apps/richdocuments/ajax/admin.php" \
-    "id:9508633,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    ctl:ruleRemoveTargetById=931130;ARGS:wopi_url,\
-    ctl:ruleRemoveTargetById=931130;ARGS:json.wopi_url"
-
-# Enabling/disabling log reader live view
-# Administration --> Logging
-SecRule REQUEST_FILENAME "@endsWith /apps/logreader/api/settings" \
-    "id:9508634,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# Configuring custom default app
-# Administration --> Theming --> Navigation bar settings
-SecRule REQUEST_FILENAME "@endsWith /apps/theming/ajax/updateAppMenu" \
-    "id:9508635,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# Deleting out of office message under
 # Personal Settings --> Availability --> Absence
+# Deleting out of office message under
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9\.]+\.php/apps/dav/api/v[0-9\.]+/outOfOffice/[^/]+$" \
-    "id:9508636,\
+    "id:9508611,\
     phase:1,\
     pass,\
     t:none,\
@@ -1822,10 +1584,10 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9\.]+\.php/apps/dav/api/v[0-9\.]+/outOfOf
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
 
-# Adjusting availability hours
 # Personal Settings --> Availability --> Availability
+# Adjusting availability hours
 SecRule REQUEST_FILENAME "@rx /remote\.php/dav/calendars/[^/]+/inbox$" \
-    "id:9508637,\
+    "id:9508612,\
     phase:1,\
     pass,\
     t:none,\
@@ -1837,9 +1599,10 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/calendars/[^/]+/inbox$" \
     ctl:ruleRemoveTargetById=942432;XML:/*,\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPPATCH'"
 
-# Deleting email addresses from personal info
+# Personal Settings --> Personal Info --> Email
+# Removing email addresses from profile
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9\.]+\.php/cloud/users/test/additional_mail$" \
-    "id:9508638,\
+    "id:9508613,\
     phase:1,\
     pass,\
     t:none,\
@@ -1847,9 +1610,10 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9\.]+\.php/cloud/users/test/additional_ma
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
 
+# Personal Settings --> Apperance and accessability --> Navigation bar settings
 # Customizing apps load order in the menu
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9\.]+/config/users/core/apporder$" \
-    "id:9508639,\
+    "id:9508614,\
     phase:1,\
     pass,\
     t:none,\
@@ -1870,12 +1634,252 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9\
     ctl:ruleRemoveTargetById=942340;ARGS:json.configValue,\
     ctl:ruleRemoveTargetById=942370;ARGS:json.configValue"
 
+# Validating password against password policy
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/password_policy/api/v[0-9]/validate$" \
+    "id:9508615,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password"
+
+# Personal Settings --> Security --> Two-Factor Authentication
+# Disabling email 2FA
+SecRule REQUEST_FILENAME "@endsWith /apps/twofactor_email/settings/disable" \
+    "id:9508616,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+# Personal Settings --> Personal Info --> Profile Visibility
+# Changing profile visibility settings
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/profile/[^/]+$" \
+    "id:9508617,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Personal Settings --> Personal Info --> Website
+# When adding a link to your own user profile
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users/$" \
+    "id:9508618,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    ctl:ruleRemoveTargetById=931130;ARGS:value,\
+    ctl:ruleRemoveTargetById=931130;ARGS:json.value"
+
+#
+# [ Administration settings ]
+#
+
+# Personal Settings --> Privacy --> Who has access to your data?
+# Deleting administrators from "Who has access to your data"
+SecRule REQUEST_FILENAME "@rx /apps/privacy/api/admins/[0-9]+$" \
+    "id:9508640,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+# Administration Settings --> Overview
+# Fix false positives with "Security and setup warnings" tests
+# Allow DAV clients to scan for dav endpoints
+SecRule REQUEST_FILENAME "@rx /\.well-known/(?:cal|car|web)dav" \
+    "id:9508641,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PROPFIND'"
+
+# Administration Settings --> Sharing --> Federated cloud sharing
+# When trying to delete a trusted server
+SecRule REQUEST_FILENAME "@contains /apps/federation/trusted-servers/" \
+    "id:9508642,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+# Administration Settings --> Basic settings --> Background jobs
+# Changing the cron method (AJAX, Webcron, Cron)
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/apps/provisioning_api/api/v[0-9]+/config/apps/core/cronErrors$" \
+    "id:9508643,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+# Administration Settings --> Security --> Two-Factor Authentication
+# Configuring/excluding 2FA enforcement for groups
+SecRule REQUEST_FILENAME "@endsWith /settings/api/admin/twofactorauth" \
+    "id:9508644,\
+    phase:1,\
+    pass,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Administration Settings --> Logging --> Log Reader Settings
+# Filtering by log level/Changing backend log level
+# Enabling/disabling log reader live view
+SecRule REQUEST_FILENAME "@rx /apps/logreader/(?:api/settings$|levels|live)" \
+    "id:9508645,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Administration Settings --> Basic Settings --> Email Server
+# Configurating an SMTP server for email notifications
+SecRule REQUEST_FILENAME "@endsWith /settings/admin/mailsettings/credentials" \
+    "id:9508646,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:mail_smtppassword"
+
+# Administration Settings --> Security --> Brute Force IP whitelist
+# Deleting whitelisted IPs for brute force protection
+SecRule REQUEST_FILENAME "@rx /apps/bruteforcesettings/ipwhitelist/[0-9]+$" \
+    "id:9508647,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+# Administration Settings --> Theming --> Advanced Options
+# Adding links foir legal notices and privacy policies
+SecRule REQUEST_FILENAME "@endsWith /apps/theming/ajax/updateStylesheet" \
+    "id:9508648,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    ctl:ruleRemoveTargetById=931130;ARGS:value,\
+    ctl:ruleRemoveTargetById=931130;ARGS:json.value"
+
+# Administration Settings --> Recognize --> CPU Cores
+# Adjusting the amount of cores used for AI facial recognition
+# This rule doesn't try to enumerate all endpoints and uses a contains instead, there's simply WAY too many to enumerate.
+# If you try, then the regex becomes unreadable and painful to work with.
+SecRule REQUEST_FILENAME "@contains /apps/recognize/admin/settings/" \
+    "id:9508649,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    ctl:ruleRemoveTargetById=932160;ARGS:value,\
+    ctl:ruleRemoveTargetById=932160;ARGS:json.value,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Administration Settings --> Flow --> File retention & automatic deletion
+# Disabling automatic deletion of a tag type
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/apps/files_retention/api/v[0-9]/retentions/[0-9]+$" \
+    "id:9508650,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+# Administration Settings --> Groupware --> Mail App
+# Disabling Microsoft/Gmail email oAuth2 intergration
+SecRule REQUEST_FILENAME "@rx /apps/mail/api/integration/(?:google|microsoft)$" \
+    "id:9508651,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
+# Administration Settings --> Log Reader
+# Viewing Nextcloud logs
+SecRule REQUEST_FILENAME "@rx /apps/logreader(?:/api)?/poll$" \
+    "id:9508652,\
+    phase:2,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    chain"
+    SecRule ARGS:lastReqId "@rx (?i)^[a-z0-9]+$" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=932236;ARGS:lastReqId,\
+        ctl:ruleRemoveTargetById=942450;ARGS:lastReqId"
+
+# Administration Settings --> Office --> Use your own server
+# Configuring WOPI URL for dedicated Collabora Server
+SecRule REQUEST_FILENAME "@endsWith /index.php/apps/richdocuments/ajax/admin.php" \
+    "id:9508653,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    ctl:ruleRemoveTargetById=931130;ARGS:wopi_url,\
+    ctl:ruleRemoveTargetById=931130;ARGS:json.wopi_url"
+
+# Administration Settings --> Theming --> Navigation bar settings
+# Configuring custom default app for all users
+SecRule REQUEST_FILENAME "@endsWith /apps/theming/ajax/updateAppMenu" \
+    "id:9508654,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
+
+# Administration Settings --> Security --> OAuth 2.0 clients
+# Creating/Deleting OAuth 2.0 clients
+SecRule REQUEST_FILENAME "@rx /apps/oauth2/clients(?:/[0-9]+)?$" \
+    "id:9508655,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
+    ctl:ruleRemoveTargetById=931130;ARGS:redirectUri,\
+    ctl:ruleRemoveTargetById=932236;ARGS:name,\
+    ctl:ruleRemoveTargetById=931130;ARGS:json.redirectUri,\
+    ctl:ruleRemoveTargetById=932236;ARGS:json.name,\
+    setvar:'tx.allowed_methods=%{tx.allowed_methods} DELETE'"
+
 #
 # [ App Store ]
 #
 
 SecRule REQUEST_FILENAME "@endsWith /settings/api/apps/media" \
-    "id:9508650,\
+    "id:9508670,\
     phase:2,\
     pass,\
     t:none,\
@@ -2055,9 +2059,8 @@ SecRule REQUEST_FILENAME "@endsWith /apps/dashboard/statuses" \
     ctl:ruleRemoveTargetById=942431;ARGS:statuses,\
     ctl:ruleRemoveTargetById=942432;ARGS:statuses"
 
-
 #
-# [ Users ]
+# [ User Management ]
 #
 
 # Allow users to be deleted and user profile settings to be updated
@@ -2074,27 +2077,6 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/[^/]+/[^/]+(?:/groups|/disa
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
     setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT DELETE'"
-
-# Allow users Profile visibility settings to be updated in Personal info
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]+\.php/profile" \
-    "id:9508851,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    setvar:'tx.allowed_methods=%{tx.allowed_methods} PUT'"
-
-# When adding a link to your own user profile
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9]\.php/cloud/users/$" \
-    "id:9508852,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-    ctl:ruleRemoveTargetById=931130;ARGS:value,\
-    ctl:ruleRemoveTargetById=931130;ARGS:json.value"
 
 #
 # [ Survey Client ]

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508600.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508600.yaml
@@ -1,0 +1,61 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Managing authentication tokens/sessions"
+  enabled: true
+  name: 9508600.yaml
+tests:
+  - test_title: 9508600-1
+    desc: Disabling filesystem access
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
+            port: 80
+            method: PUT
+            uri: /settings/personal/authtokens/1
+            data: |
+              {"id":1,"name":"test","lastActivity":1721401548,"type":1,"scope":{"filesystem":false},"canDelete":true,"canRename":true}
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "911100"
+  - test_title: 9508600-2
+    desc: Renaming a token/session
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
+            port: 80
+            method: PUT
+            uri: /settings/personal/authtokens/1
+            data: |
+              {"id":1,"name":"test123","lastActivity":1721401548,"type":1,"scope":{"filesystem":false},"canDelete":true,"canRename":true}
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "911100"
+  - test_title: 9508600-3
+    desc: Deleting a token/session
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: DELETE
+            uri: /settings/personal/authtokens/1
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508604.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508604.yaml
@@ -1,0 +1,42 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508604.yaml
+tests:
+  - test_title: 9508604-1
+    desc: Enabling "Automatically set user status to Do no disturb" option
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
+            port: 80
+            method: POST
+            uri: /ocs/v2.php/apps/provisioning_api/api/v1/config/users/dav/user_status_automation
+            data: |
+              {"configValue":"yes"}
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "911100"
+  - test_title: 9508604-2
+    desc: Disabling "Automatically set user status to Do no disturb" option
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: DELETE
+            uri: /ocs/v2.php/apps/provisioning_api/api/v1/config/users/dav/user_status_automation
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508605.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508605.yaml
@@ -1,0 +1,24 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508605.yaml
+tests:
+  - test_title: 9508605-1
+    desc: Disabling dyslexic font
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
+            port: 80
+            method: DELETE
+            uri: /ocs/v2.php/apps/theming/api/v1/theme/opendyslexic
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508609.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508609.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Esad Cetiner"
   description: "FPs when registering webauthn devices"
   enabled: true
-  name: 9508624.yaml
+  name: 9508609.yaml
 tests:
-  - test_title: 9508624-1
+  - test_title: 9508609-1
     desc: Registering webauthn device with pretty URLs
     stages:
       - stage:
@@ -25,7 +25,7 @@ tests:
           output:
             no_log_contains: |-
               id "920273"|id "932236"|id "942200"|id "942260"|id "942340"|id "942370"|id "942430"|id "942431"|id "942432"
-  - test_title: 9508624-2
+  - test_title: 9508609-2
     desc: Registering webauthn device without pretty URLs
     stages:
       - stage:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508611.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508611.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508635.yaml
+  name: 9508611.yaml
 tests:
-  - test_title: 9508635-1
-    desc: Configuring default apps
+  - test_title: 9508611-1
+    desc: Deleting out of office message
     stages:
       - stage:
           input:
@@ -15,12 +15,9 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
             port: 80
-            method: PUT
-            uri: /apps/logreader/api/settings
-            data: |
-              { "setting":"defaultApps","value":["files","dashboard"] }
+            method: DELETE
+            uri: /ocs/v2.php/apps/dav/api/v1/outOfOffice/username
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508612.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508612.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508637.yaml
+  name: 9508612.yaml
 tests:
-  - test_title: 9508637-1
+  - test_title: 9508612-1
     desc: Adjusting availability hours
     stages:
       - stage:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508613.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508613.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508852.yaml
+  name: 9508613.yaml
 tests:
-  - test_title: 9508852-1
-    desc: Adding a link to user profile
+  - test_title: 9508613-1
+    desc: Deleting an email address from personal info
     stages:
       - stage:
           input:
@@ -17,10 +17,10 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
-            method: POST
+            method: PUT
+            uri: /ocs/v2.php/cloud/users/test/additional_mail
             data: |
-              {"value": "https://example.com/"}
-            uri: /ocs/v2.php/cloud/users/
+              {"key":"email@example.com","value":""}
             version: HTTP/1.1
           output:
-            no_log_contains: id "931130"
+            no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508614.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508614.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508639.yaml
+  name: 9508614.yaml
 tests:
-  - test_title: 9508639-1
+  - test_title: 9508614-1
     desc: Changing the ordering of apps in the menu
     stages:
       - stage:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508616.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508616.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508650.yaml
+  name: 9508616.yaml
 tests:
-  - test_title: 9508650-1
-    desc: Disabling automatic deletion of a tag type
+  - test_title: 9508616-1
+    desc: Disabling 2FA email
     stages:
       - stage:
           input:
@@ -17,7 +17,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
-            uri: /ocs/v2.php/apps/files_retention/api/v2/retentions/42
+            uri: /apps/twofactor_email/settings/disable
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508618.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508618.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508629.yaml
+  name: 9508618.yaml
 tests:
-  - test_title: 9508629-1
-    desc: Disabling automatic deletion of a tag type
+  - test_title: 9508618-1
+    desc: Adding a link to user profile
     stages:
       - stage:
           input:
@@ -15,9 +15,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
-            method: DELETE
-            uri: /ocs/v2.php/apps/files_retention/api/v2/retentions/42
+            method: POST
+            data: |
+              {"value": "https://example.com/"}
+            uri: /ocs/v2.php/cloud/users/
             version: HTTP/1.1
           output:
-            no_log_contains: id "911100"
+            no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508640.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508640.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508632.yaml
+  name: 9508640.yaml
 tests:
-  - test_title: 9508632-1
-    desc: Disabling 2FA email
+  - test_title: 9508640-1
+    desc: Deleting administrators from "Who has access to your data"
     stages:
       - stage:
           input:
@@ -17,7 +17,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
-            uri: /apps/twofactor_email/settings/disable
+            uri: /apps/privacy/api/admins/1
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508643.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508643.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508650.yaml
+  name: 9508643.yaml
 tests:
-  - test_title: 9508650-1
-    desc: Disabling automatic deletion of a tag type
+  - test_title: 9508643-1
+    desc: Changing the cron method (AJAX, Webcron, Cron)
     stages:
       - stage:
           input:
@@ -17,7 +17,7 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
             port: 80
             method: DELETE
-            uri: /ocs/v2.php/apps/files_retention/api/v2/retentions/42
+            uri: /ocs/v2.php/apps/provisioning_api/api/v1/config/apps/core/cronErrors
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508644.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508644.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508638.yaml
+  name: 9508644.yaml
 tests:
-  - test_title: 9508638-1
-    desc: Deleting an email address from personal info
+  - test_title: 9508644-1
+    desc: Configuring/excluding 2FA enforcement for groups
     stages:
       - stage:
           input:
@@ -18,9 +18,9 @@ tests:
               Content-Type: application/json
             port: 80
             method: PUT
-            uri: /ocs/v2.php/cloud/users/test/additional_mail
+            uri: /settings/api/admin/twofactorauth
             data: |
-              {"key":"email@example.com","value":""}
+              {"enforced":true,"enforcedGroups":["admin"],"excludedGroups":["Users"]}
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508645.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508645.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508630.yaml
+  name: 9508645.yaml
 tests:
-  - test_title: 9508630-1
-    desc: Disabling Gmail email integration
+  - test_title: 9508645-1
+    desc: Disabling log reader live view
     stages:
       - stage:
           input:
@@ -15,14 +15,17 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
-            method: DELETE
-            uri: /apps/mail/api/integration/google
+            method: PUT
+            uri: /apps/logreader/api/settings
+            data: |
+              { "settingsKey": "liveLog","settingsValue": false }
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"
-  - test_title: 9508630-2
-    desc: Disabling Microsoft email integration
+  - test_title: 9508645-2
+    desc: Enabling log reader live view
     stages:
       - stage:
           input:
@@ -31,9 +34,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
-            method: DELETE
-            uri: /apps/mail/api/integration/microsoft
+            method: PUT
+            uri: /apps/logreader/api/settings
+            data: |
+              { "settingsKey": "liveLog","settingsValue": true }
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508651.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508651.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508634.yaml
+  name: 9508651.yaml
 tests:
-  - test_title: 9508634-1
-    desc: Disabling log reader live view
+  - test_title: 9508651-1
+    desc: Disabling Gmail email integration
     stages:
       - stage:
           input:
@@ -15,17 +15,14 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
             port: 80
-            method: PUT
-            uri: /apps/logreader/api/settings
-            data: |
-              { "settingsKey": "liveLog","settingsValue": false }
+            method: DELETE
+            uri: /apps/mail/api/integration/google
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"
-  - test_title: 9508634-2
-    desc: Enabling log reader live view
+  - test_title: 9508651-2
+    desc: Disabling Microsoft email integration
     stages:
       - stage:
           input:
@@ -34,12 +31,9 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
-              Content-Type: application/json
             port: 80
-            method: PUT
-            uri: /apps/logreader/api/settings
-            data: |
-              { "settingsKey": "liveLog","settingsValue": true }
+            method: DELETE
+            uri: /apps/mail/api/integration/microsoft
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508652.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508652.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508631.yaml
+  name: 9508652.yaml
 tests:
-  - test_title: 9508631-1
+  - test_title: 9508652-1
     desc: Viewing Nextcloud log files via web GUI
     stages:
       - stage:
@@ -22,7 +22,7 @@ tests:
             uri: /apps/logreader/poll
           output:
             no_log_contains: id "932236"
-  - test_title: 9508631-2
+  - test_title: 9508652-2
     desc: Viewing Nextcloud log files via web GUI
     stages:
       - stage:
@@ -39,7 +39,7 @@ tests:
             uri: /apps/logreader/poll
           output:
             no_log_contains: id "942450"
-  - test_title: 9508631-3
+  - test_title: 9508652-3
     desc: Viewing Nextcloud log files via web GUI
     stages:
       - stage:
@@ -55,7 +55,7 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: id "932236"
-  - test_title: 9508631-4
+  - test_title: 9508652-4
     desc: Viewing Nextcloud log files via web GUI
     stages:
       - stage:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508653.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508653.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508636.yaml
+  name: 9508653.yaml
 tests:
-  - test_title: 9508636-1
-    desc: Deleting out of office message
+  - test_title: 9508653-1
+    desc: Configuring WOPI URL for dedicated Collabora Server
     stages:
       - stage:
           input:
@@ -15,9 +15,12 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
-            method: DELETE
-            uri: /ocs/v2.php/apps/dav/api/v1/outOfOffice/username
+            method: POST
+            uri: /index.php/apps/richdocuments/ajax/admin.php
+            data: |
+              {"wopi_url": "https://example.com/"}
             version: HTTP/1.1
           output:
-            no_log_contains: id "911100"
+            no_log_contains: id "931130"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508654.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508654.yaml
@@ -3,10 +3,10 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508633.yaml
+  name: 9508654.yaml
 tests:
-  - test_title: 9508633-1
-    desc: Configuring WOPI URL for dedicated Collabora Server
+  - test_title: 9508654-1
+    desc: Configuring default apps
     stages:
       - stage:
           input:
@@ -17,10 +17,10 @@ tests:
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
               Content-Type: application/json
             port: 80
-            method: POST
-            uri: /index.php/apps/richdocuments/ajax/admin.php
+            method: PUT
+            uri: /apps/theming/ajax/updateAppMenu
             data: |
-              {"wopi_url": "https://example.com/"}
+              { "setting":"defaultApps","value":["files","dashboard"] }
             version: HTTP/1.1
           output:
-            no_log_contains: id "931130"
+            no_log_contains: id "911100"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508655.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508655.yaml
@@ -3,9 +3,9 @@ meta:
   author: "Esad Cetiner"
   description: "Nextcloud Rule Exclusions Plugin"
   enabled: true
-  name: 9508628.yaml
+  name: 9508655.yaml
 tests:
-  - test_title: 9508628-1
+  - test_title: 9508655-1
     desc: Deleting an oauth client
     stages:
       - stage:
@@ -21,7 +21,7 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"
-  - test_title: 9508628-2
+  - test_title: 9508655-2
     desc: Deleting an oauth client
     stages:
       - stage:
@@ -37,7 +37,7 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: id "911100"
-  - test_title: 9508628-3
+  - test_title: 9508655-3
     desc: Specifying a redirect URL for oauth clients
     stages:
       - stage:
@@ -56,7 +56,7 @@ tests:
             version: HTTP/1.1
           output:
             no_log_contains: id "931130"
-  - test_title: 9508628-4
+  - test_title: 9508655-4
     desc: Specifying a redirect URL for oauth clients
     stages:
       - stage:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508670.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508670.yaml
@@ -1,0 +1,39 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508670.yaml
+tests:
+  - test_title: 9508670-1
+    desc: Displaying discover page in the app store
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: GET
+            uri: /settings/api/apps/media?fileName=https%3A%2F%2Fnextcloud.com%2Fc%2Fuploads%2F2024%2F04%2Fhub8-release-featured-image-1024x576.jpg
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "931130"
+  - test_title: 9508670-2
+    desc: Displaying discover page in the app store
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: GET
+            uri: /settings/api/apps/media?fileName=https%3A%2F%2Fgithub.com%2Fnextcloud%2Ffirstrunwizard%2Fraw%2Fmaster%2Fimg%2FNextcloud.webm
+            version: HTTP/1.1
+          output:
+            no_log_contains: id "931130"


### PR DESCRIPTION
Over the past year the Nextcloud plugin has grown dramatically in size with improved coverage and support for various features within Nextcloud, this has come at the expense of code readability and maintainability. Rule IDs have grown from 53 to 185 and the lines of code from 780 to 2756.

This PR is focused on overhauling personal/administration settings and has:

- Reduced the number of rules down to 181 (from 185)
- Rule exclusions have been reorganized to make it easier to find/modify/add rule exclusions relating to settings
- Comment clarity has been improved
- 6 Additional tests have been added

The Nextcloud plugin will likely remain large since Nextcloud incredibly feature rich, but it's a start.
