### PR TITLE
docs: update locations for increasing max file upload size

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,9 @@ For full and up to date instructions for the different available plugin installa
 
 Large uploads can be modified with SecRequestBodyLimit. Or they can be more controlled by using the following:
 
+Apache with ModSecurity2:
 ```
-SecRule REQUEST_FILENAME "@endsWith /index.php/apps/files/ajax/upload.php" \
+SecRule REQUEST_FILENAME "@rx (?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/))" \
     "id:9508610,\
     phase:1,\
     t:none,\
@@ -62,14 +63,14 @@ ctl:requestBodyLimit is not supported in libmodsecurity3, Nginx users can increa
 by using the following:
 
 ```
-location /index.php/apps/files/ajax/upload.php { modsecurity_rules 'SecRequestBodyLimit 1073741824'; }
+location ~ (?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/)) { modsecurity_rules 'SecRequestBodyLimit 1073741824'; }
 ```
 
 Apache libmodsecurity3 Example:
 ```
- <location "/index.php/apps/files/ajax/upload.php">
+<LocationMatch "(?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/))">
     modsecurity_rules 'SecRequestBodyLimit 1073741824'
-</location>
+</LocationMatch>
 ```
 
 ## Relaxing file upload restrictions

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -19,61 +19,11 @@
 # Generic rule to disable plugin
 SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,pass,nolog,ctl:ruleRemoveById=9508100-9508999"
 
+# This plugin will resolve most false positives in Nextcloud, however due to some limitations this plugin can't
+# fix all file upload related false positives out of the box. Please see the README.md file on how to resolve these false positives.
+# See: https://github.com/coreruleset/nextcloud-rule-exclusions-plugin?tab=readme-ov-file#increasing-max-upload-size
 
-# These exclusions remedy false positives in a default Nextcloud install.
-# They will likely work with OwnCloud too, but you may have to modify them.
 #
-# To relax upload restrictions for only the php files that need it,
-# you put something like this in crs-setup.conf:
-#
-# SecRule REQUEST_FILENAME "@rx /(?:remote\.php|index\.php)/" \
-#     "id:9508600,\
-#     phase:2,\
-#     t:none,\
-#     nolog,\
-#     pass,\
-#     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-#     setvar:'tx.restricted_extensions=.bak/ .config/ .conf/'"
-#
-# Large uploads can be modified with SecRequestBodyLimit. Or they
-# can be more controlled by using the following:
-#
-# SecRule REQUEST_FILENAME "@endsWith /index.php/apps/files/ajax/upload.php" \
-#     "id:9508610,\
-#     phase:1,\
-#     t:none,\
-#     nolog,\
-#     ver:'nextcloud-rule-exclusions-plugin/1.2.0',\
-#     ctl:requestBodyLimit=1073741824"
-#
-# ctl:requestBodyLimit is not supported in libmodsecurity3, Nginx users can increase max upload size
-# by using the following:
-# location /index.php/apps/files/ajax/upload.php { modsecurity_rules 'SecRequestBodyLimit 1073741824'; }
-#
-# Apache libmodsecurity3 Example:
-# <location "/index.php/apps/files/ajax/upload.php">
-#    modsecurity_rules 'SecRequestBodyLimit 1073741824'
-# </location>
-#
-#
-# The Nextcloud desktop client occasionally sends large request bodies not containing any uploaded files.
-# ModSecurity will block request bodies larger than 131KB, adjusting SecRequestBodyNoFilesLimit to
-# 141KB works for all scenarios tested.
-#
-# Nginx libmodsecurity3 Example:
-# location /remote.php/dav/files/ { modsecurity_rules 'SecRequestBodyNoFilesLimit 144384'; }
-#
-# Apache modsecurity2 Example:
-# <location "/remote.php/dav/files/">
-#     SecRequestBodyNoFilesLimit 144384
-# </location>
-#
-# Apache libmodsecurity3 Example:
-# <location "/remote.php/dav/files/">
-#    modsecurity_rules 'SecRequestBodyNoFilesLimit 144384'
-# </location>
-
-
 # [ Local CRS initialization ]
 #
 # We need to initialize some of the CRS variables also here because plugin setup runs before


### PR DESCRIPTION
Updates the docs on how to increase the max file upload size for file uploads. Newer versions of Nextcloud upload files to the remote.php endpoint