### PR TITLE
fix: creating/viewing an album in photos app

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -2227,7 +2227,7 @@ SecRule REQUEST_FILENAME "@rx /apps/photos/api/v[0-9]+/preview/[0-9]+$" \
 # Photos: Albums, Shared Albums, Places
 # Allow the data type 'text/plain'
 # Since the content is actually XML, we switch on the XML parser
-SecRule REQUEST_FILENAME "@rx /remote\.php/dav/photos/[^/]+/(?:albums|sharedalbums|places)(?:/[^/]+)?/$" \
+SecRule REQUEST_FILENAME "@rx /remote\.php/dav/photos/[^/]+/(?:albums|sharedalbums|places)(?:/[^/]+)?/?$" \
     "id:9508952,\
     phase:1,\
     pass,\

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508952.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508952.yaml
@@ -1,0 +1,37 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Photos"
+  enabled: true
+  name: 9508952.yaml
+tests:
+  - test_title: 9508952-1
+    desc: Creating/viewing a photo album
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: text/plain;charset=UTF-8
+            port: 80
+            method: PROPFIND
+            uri: /remote.php/dav/photos/esadc/albums/test
+            data: |
+              <?xml version="1.0"?>
+              <d:propfind xmlns:d="DAV:"
+                xmlns:oc="http://owncloud.org/ns"
+                xmlns:nc="http://nextcloud.org/ns"
+                xmlns:ocs="http://open-collaboration-services.org/ns">
+                <d:prop>
+                  <nc:last-photo />
+                  <nc:nbItems />
+                  <nc:location /><nc:dateRange /><nc:collaborators />
+                </d:prop>
+              </d:propfind>
+            version: HTTP/1.1
+          output:
+            no_log_contains: |-
+              id "920420"|id "921110"


### PR DESCRIPTION
Fix false positive when creating/viewing a photo album by making the `/` at the end optional.