### PR TITLE
fix: add workaround for ios file upload issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Apache with ModSecurity2:
 </LocationMatch>
 ```
 
-NGINX with libModSecurity3:
+nginx with libModSecurity3:
 
 ```
 location ~ (?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/)) { 
@@ -91,7 +91,7 @@ Apache with libmodsecurity3:
 
 ### Fixing file uploads on iOS
 
-The Nextcloud iOS app does not set the correct content type when uploading files, which causes issues with CRS as it relies on the content type to correctly parse data.
+The Nextcloud iOS app does not set the correct content type when uploading files, which causes issues with ModSecurity as it relies on the content type to correctly parse data.
 There's a workaround included with the plugin but it's disabled by default due to a bypass risk, if you use the Nextcloud iOS app then uncomment rule `9508011` in `nextcloud-rule-exclusions-config.conf` to enable the workaround.
 The workaround will be removed when this issue is fixed within the iOS app.
 See: https://github.com/nextcloud/ios/issues/1942

--- a/README.md
+++ b/README.md
@@ -57,54 +57,36 @@ Below you can find a list of known limitations along with workarounds for this i
 
 ### Increasing max upload size
 
-Large uploads can be modified with SecRequestBodyLimit. Or they can be more controlled by using the following:
+ModSecurity has very strict defaults on the size of file uploads (13MB), which is often too small even for photos.
+It's strongly recommended to increase the max upload size to a value like 1GB by adjusting both `SecRequestBodyNoFilesLimit` and `SecRequestBodyLimit`.
+
+The process of increasing the value is slightly different depending on your web server, see below for some examples.
+
+**NOTE:** SecRequestBodyNoFilesLimit changes the max size for the request body, and not the max file upload size. Due to how Nextcloud iOS uploads files ModSecurity does not recognize it as a file upload.
 
 Apache with ModSecurity2:
 ```
-SecRule REQUEST_FILENAME "@rx (?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/))" \
-    "id:9508030,\
-    phase:1,\
-    t:none,\
-    nolog,\
-    ctl:requestBodyLimit=1073741824"
-```
-
-ctl:requestBodyLimit is not supported in libmodsecurity3, Nginx users can increase max upload size
-by using the following:
-
-```
-location ~ (?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/)) { modsecurity_rules 'SecRequestBodyLimit 1073741824'; }
-```
-
-Apache libmodsecurity3 Example:
-```
 <LocationMatch "(?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/))">
-    modsecurity_rules 'SecRequestBodyLimit 1073741824'
+    SecRequestBodyLimit 1073741824
+    SecRequestBodyNoFilesLimit 1073741824
 </LocationMatch>
 ```
 
-### Increasing max request body size
+NGINX with libModSecurity3:
 
-The Nextcloud desktop client occasionally sends large request bodies not containing any uploaded files.
-ModSecurity will block request bodies larger than 131KB, adjusting SecRequestBodyNoFilesLimit to 141KB works for all scenarios tested.
-
-Nginx libmodsecurity3 Example:
 ```
-location /remote.php/dav/files/ { modsecurity_rules 'SecRequestBodyNoFilesLimit 144384'; }
-```
-
-Apache modsecurity2 Example:
-```
-<location "/remote.php/dav/files/">
-   SecRequestBodyNoFilesLimit 144384
-</location>
+location ~ (?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/)) { 
+    modsecurity_rules 'SecRequestBodyLimit 1073741824
+    SecRequestBodyNoFilesLimit 1073741824'; 
+}
 ```
 
-Apache libmodsecurity3 Example:
+Apache with libmodsecurity3:
 ```
-<location "/remote.php/dav/files/">
-   modsecurity_rules 'SecRequestBodyNoFilesLimit 144384'
-</location>
+<LocationMatch "(?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/))">
+    modsecurity_rules 'SecRequestBodyLimit 1073741824
+    SecRequestBodyNoFilesLimit 1073741824';
+</LocationMatch>
 ```
 
 ### Nextcloud Server Crawler

--- a/README.md
+++ b/README.md
@@ -89,6 +89,13 @@ Apache with libmodsecurity3:
 </LocationMatch>
 ```
 
+### Fixing file uploads on iOS
+
+The Nextcloud iOS app does not set the correct content type when uploading files, which causes issues with CRS as it relies on the content type to correctly parse data.
+There's a workaround included with the plugin but it's disabled by default due to a bypass risk, if you use the Nextcloud iOS app then uncomment rule `9508011` in `nextcloud-rule-exclusions-config.conf` to enable the workaround.
+The workaround will be removed when this issue is fixed within the iOS app.
+See: https://github.com/nextcloud/ios/issues/1942
+
 ### Nextcloud Server Crawler
 
 The Nextcloud Server Crawler is used by Nextcloud for various functions of Nextcloud such as generating document previews with Collabora, and testing the functionality of Nextcloud (for example, when setting up the high performance backend for files).

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Below you can find a list of known limitations along with workarounds for this i
 ### Increasing max upload size
 
 ModSecurity has very strict defaults on the size of file uploads (13MB), which is often too small even for photos.
-It's strongly recommended to increase the max upload size to a value like 1GB by adjusting both `SecRequestBodyNoFilesLimit` and `SecRequestBodyLimit`.
+It's strongly recommended to increase the max upload size to a value like 10GB by adjusting both `SecRequestBodyNoFilesLimit` and `SecRequestBodyLimit`.
 
 The process of increasing the value is slightly different depending on your web server, see below for some examples.
 
@@ -67,8 +67,8 @@ The process of increasing the value is slightly different depending on your web 
 Apache with ModSecurity2:
 ```
 <LocationMatch "(?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/))">
-    SecRequestBodyLimit 1073741824
-    SecRequestBodyNoFilesLimit 1073741824
+    SecRequestBodyLimit 10737418240
+    SecRequestBodyNoFilesLimit 10737418240
 </LocationMatch>
 ```
 
@@ -76,16 +76,16 @@ NGINX with libModSecurity3:
 
 ```
 location ~ (?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/)) { 
-    modsecurity_rules 'SecRequestBodyLimit 1073741824
-    SecRequestBodyNoFilesLimit 1073741824'; 
+    modsecurity_rules 'SecRequestBodyLimit 10737418240
+    SecRequestBodyNoFilesLimit 10737418240'; 
 }
 ```
 
 Apache with libmodsecurity3:
 ```
 <LocationMatch "(?:/index\.php/apps/files/ajax/upload\.php|/remote\.php/dav/(?:bulk|files/|uploads/))">
-    modsecurity_rules 'SecRequestBodyLimit 1073741824
-    SecRequestBodyNoFilesLimit 1073741824';
+    modsecurity_rules 'SecRequestBodyLimit 10737418240
+    SecRequestBodyNoFilesLimit 10737418240';
 </LocationMatch>
 ```
 

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -16,6 +16,9 @@
 # Documentation can be found here:
 # https://github.com/coreruleset/nextcloud-rule-exclusions-plugin
 
+# Disable workaround for iOS file upload by default
+SecRule TX:nextcloud-rule-exclusions-plugin_ios_workaround_enabled "@eq 0" "id:9508098,phase:1,pass,nolog,ctl:ruleRemoveById=9508119"
+
 # Generic rule to disable plugin
 SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,pass,nolog,ctl:ruleRemoveById=9508100-9508999"
 
@@ -202,6 +205,57 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/uploads/[^/]+/[0-9]+/\.file$" \
     SecRule &REQUEST_HEADERS:if "@eq 1" \
         "t:none,\
         ctl:ruleRemoveById=920450"
+
+# WebDAV client searching for files.
+# The / at the end is sometimes missing.
+SecRule REQUEST_FILENAME "@rx /remote\.php/dav/?$" \
+    "id:9508118,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.3.1',\
+    chain"
+    SecRule REQUEST_METHOD "@streq SEARCH" \
+        "t:none,\
+        ctl:ruleRemoveTargetById=942430;XML:/*,\
+        ctl:ruleRemoveTargetById=942431;XML:/*,\
+        ctl:ruleRemoveTargetById=942432;XML:/*"
+
+# The Nextcloud iOS app sets an incorrect content type when uploading binary data. It uses either
+# application/xml or application/x-www-form-urlencoded content type instead of application/octet-stream.
+# This data isn't parseable by ModSecurity, so this rule essentially disables all rules for the request body.
+# There's a real risk this rule could introduce a bypass, so it's disabled by default and should only be enabled
+# if really needed. This rule is just a workaround, this should be fixed within the iOS app.
+# See:
+#   - https://github.com/nextcloud/ios/issues/1942
+#   - https://coreruleset.org/20210630/cve-2021-35368-crs-request-body-bypass/
+#   - https://nvd.nist.gov/vuln/detail/CVE-2021-35368
+SecRule REQUEST_FILENAME "@rx /remote\.php/dav/(?:files/|uploads/[^/]+/[^/]+(?:/[^/]+)?$)" \
+    "id:9508119,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.3.1',\
+    chain"
+    SecRule REQUEST_HEADERS:User-Agent "@contains Nextcloud-iOS" \
+        "t:none,\
+        chain"
+        SecRule REQUEST_HEADERS:Content-Type "@rx ^application/(?:x-www-form-urlencoded|xml)$" \
+            "t:none,\
+            chain"
+            SecRule REQUEST_METHOD "@pm POST PUT" \
+                "t:none,\
+                ctl:ruleRemoveById=200002,\
+                ctl:ruleRemoveById=200007,\
+                ctl:ruleRemoveById=920240,\
+                ctl:ruleRemoveById=920250,\
+                ctl:ruleRemoveTargetById=920540;ARGS,\
+                ctl:ruleRemoveTargetById=920540;ARGS_NAMES,\
+                ctl:ruleRemoveTargetById=921110;REQUEST_BODY,\
+                ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS,\
+                ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS_NAMES"
 
 #
 # [ File Manager - Web GUI ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -17,7 +17,7 @@
 # https://github.com/coreruleset/nextcloud-rule-exclusions-plugin
 
 # Disable workaround for iOS file upload by default
-SecRule TX:nextcloud-rule-exclusions-plugin_ios_workaround_enabled "@eq 0" "id:9508098,phase:1,pass,nolog,ctl:ruleRemoveById=9508119"
+SecRule &TX:nextcloud-rule-exclusions-plugin_ios_workaround_enabled "@eq 0" "id:9508098,phase:1,pass,nolog,ctl:ruleRemoveById=9508119"
 
 # Generic rule to disable plugin
 SecRule TX:nextcloud-rule-exclusions-plugin_enabled "@eq 0" "id:9508099,phase:1,pass,nolog,ctl:ruleRemoveById=9508100-9508999"

--- a/plugins/nextcloud-rule-exclusions-config.conf
+++ b/plugins/nextcloud-rule-exclusions-config.conf
@@ -44,7 +44,7 @@
 #     setvar:'tx.nextcloud-rule-exclusions-plugin_enabled=0'"
 
 # The Nextcloud iOS app does not set the correct content type when uploading files,
-# which causes issues with CRS as it relies on the content type to correctly parse data.
+# which causes issues with ModSecurity as it relies on the content type to correctly parse data.
 # There's a workaround included with the plugin but it's disabled by default due to a bypass risk,
 # if you use the Nextcloud iOS app then uncomment this rule to enable the workaround.
 # This workaround will be removed when this issue is fixed within the iOS app.

--- a/plugins/nextcloud-rule-exclusions-config.conf
+++ b/plugins/nextcloud-rule-exclusions-config.conf
@@ -9,7 +9,7 @@
 
 # OWASP CRS Plugin
 # Plugin name: nextcloud-rule-exclusions
-# Plugin description: 
+# Plugin description:
 # Rule ID block base: 9,508,000 - 9,508,999
 # Plugin version: 1.3.1
 

--- a/plugins/nextcloud-rule-exclusions-config.conf
+++ b/plugins/nextcloud-rule-exclusions-config.conf
@@ -46,7 +46,7 @@
 # The Nextcloud iOS app does not set the correct content type when uploading files,
 # which causes issues with CRS as it relies on the content type to correctly parse data.
 # There's a workaround included with the plugin but it's disabled by default due to a bypass risk,
-# if you use the Nextcloud iOS app then you should uncomment this rule to enable the workaround.
+# if you use the Nextcloud iOS app then uncomment this rule to enable the workaround.
 # This workaround will be removed when this issue is fixed within the iOS app.
 # See: https://github.com/nextcloud/ios/issues/1942
 # SecAction \

--- a/plugins/nextcloud-rule-exclusions-config.conf
+++ b/plugins/nextcloud-rule-exclusions-config.conf
@@ -42,3 +42,17 @@
 #     nolog,\
 #     ver:'nextcloud-rule-exclusions-plugin/1.3.1',\
 #     setvar:'tx.nextcloud-rule-exclusions-plugin_enabled=0'"
+
+# The Nextcloud iOS app does not set the correct content type when uploading files,
+# which causes issues with CRS as it relies on the content type to correctly parse data.
+# There's a workaround included with the plugin but it's disabled by default due to a bypass risk,
+# if you use the Nextcloud iOS app then you should uncomment this rule to enable the workaround.
+# This workaround will be removed when this issue is fixed within the iOS app.
+# See: https://github.com/nextcloud/ios/issues/1942
+# SecAction \
+#     "id:9508011,\
+#     phase:1,\
+#     pass,\
+#     nolog,\
+#     ver:'nextcloud-rule-exclusions-plugin/1.3.1',\
+#     setvar:'tx.nextcloud-rule-exclusions-plugin_ios_workaround_enabled=1'"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508118.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508118.yaml
@@ -1,0 +1,239 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508118.yaml
+tests:
+  - test_title: 9508118-1
+    desc: WebDAV client searching for files
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: text/xml
+            port: 80
+            method: SEARCH
+            uri: /remote.php/dav
+            data: |-
+              <?xml version="1.0" encoding="UTF-8"?>
+                <d:searchrequest xmlns:d="DAV:"
+                  xmlns:oc="http://owncloud.org/ns"
+                  xmlns:nc="http://nextcloud.org/ns"
+                  xmlns:ns="https://github.com/icewind1991/SearchDAV/ns"
+                  xmlns:ocs="http://open-collaboration-services.org/ns">
+                  <d:basicsearch>
+                    <d:select>
+                    <d:prop>
+                    <d:getcontentlength/>
+                    <d:getcontenttype/>
+                    <d:getetag/>
+                    <d:getlastmodified/>
+                    <d:resourcetype/>
+                    <nc:face-detections/>
+                    <nc:face-preview-image/>
+                    <nc:metadata-photos-size/>
+                    <nc:metadata-photos-original_date_time/>
+                    <nc:metadata-files-live-photo/>
+                    <nc:metadata-blurhash/>
+                    <nc:has-preview/>
+                    <nc:realpath/>
+                    <nc:hidden/>
+                    <oc:favorite/>
+                    <oc:fileid/>
+                    <oc:permissions/>
+                    <nc:nbItems/>
+                    </d:prop>
+                    </d:select>
+                    <d:from>
+                    <d:scope>
+                    <d:href>/files/esadc/Pictures</d:href>
+                    <d:depth>infinity</d:depth>
+                    </d:scope>
+                    <d:scope>
+                    <d:href>/files/esadc/InstantUpload</d:href>
+                    <d:depth>infinity</d:depth>
+                    </d:scope>
+                    </d:from>
+                    <d:where>
+                    <d:and>
+                    <d:or>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>image/png</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>image/jpeg</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>image/heic</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>image/webp</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>video/mp4</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>video/quicktime</d:literal>
+                    </d:eq>
+                    </d:or>
+                    </d:and>
+                    </d:where>
+                    <d:orderby>
+                    <d:order>
+                    <d:prop><nc:metadata-photos-original_date_time/></d:prop>
+                    <d:descending/>
+                    </d:order>
+                    <d:order>
+                    <d:prop><d:getlastmodified/></d:prop>
+                    <d:descending/>
+                    </d:order>
+                    </d:orderby>
+                    <d:limit>
+                    <d:nresults>200</d:nresults>
+                    <ns:firstresult>200</ns:firstresult>
+                    </d:limit>
+                  </d:basicsearch>
+                </d:searchrequest>
+            version: HTTP/1.1
+          output:
+            no_log_contains: |-
+              id "911100"|id "942430"|id "942431"|id "942432"
+  - test_title: 9508118-2
+    desc: WebDAV client searching for files
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: text/xml
+            port: 80
+            method: SEARCH
+            uri: /remote.php/dav/
+            data: |-
+              <?xml version="1.0" encoding="UTF-8"?>
+                <d:searchrequest xmlns:d="DAV:"
+                  xmlns:oc="http://owncloud.org/ns"
+                  xmlns:nc="http://nextcloud.org/ns"
+                  xmlns:ns="https://github.com/icewind1991/SearchDAV/ns"
+                  xmlns:ocs="http://open-collaboration-services.org/ns">
+                  <d:basicsearch>
+                    <d:select>
+                    <d:prop>
+                    <d:getcontentlength/>
+                    <d:getcontenttype/>
+                    <d:getetag/>
+                    <d:getlastmodified/>
+                    <d:resourcetype/>
+                    <nc:face-detections/>
+                    <nc:face-preview-image/>
+                    <nc:metadata-photos-size/>
+                    <nc:metadata-photos-original_date_time/>
+                    <nc:metadata-files-live-photo/>
+                    <nc:metadata-blurhash/>
+                    <nc:has-preview/>
+                    <nc:realpath/>
+                    <nc:hidden/>
+                    <oc:favorite/>
+                    <oc:fileid/>
+                    <oc:permissions/>
+                    <nc:nbItems/>
+                    </d:prop>
+                    </d:select>
+                    <d:from>
+                    <d:scope>
+                    <d:href>/files/esadc/Pictures</d:href>
+                    <d:depth>infinity</d:depth>
+                    </d:scope>
+                    <d:scope>
+                    <d:href>/files/esadc/InstantUpload</d:href>
+                    <d:depth>infinity</d:depth>
+                    </d:scope>
+                    </d:from>
+                    <d:where>
+                    <d:and>
+                    <d:or>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>image/png</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>image/jpeg</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>image/heic</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>image/webp</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>video/mp4</d:literal>
+                    </d:eq>
+                    <d:eq>
+                    <d:prop>
+                    <d:getcontenttype/>
+                    </d:prop>
+                    <d:literal>video/quicktime</d:literal>
+                    </d:eq>
+                    </d:or>
+                    </d:and>
+                    </d:where>
+                    <d:orderby>
+                    <d:order>
+                    <d:prop><nc:metadata-photos-original_date_time/></d:prop>
+                    <d:descending/>
+                    </d:order>
+                    <d:order>
+                    <d:prop><d:getlastmodified/></d:prop>
+                    <d:descending/>
+                    </d:order>
+                    </d:orderby>
+                    <d:limit>
+                    <d:nresults>200</d:nresults>
+                    <ns:firstresult>200</ns:firstresult>
+                    </d:limit>
+                  </d:basicsearch>
+                </d:searchrequest>
+            version: HTTP/1.1
+          output:
+            no_log_contains: |-
+              id "911100"|id "942430"|id "942431"|id "942432"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508119.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508119.yaml
@@ -19,10 +19,10 @@ tests:
             port: 80
             method: POST
             uri: /remote.php/dav/files/something
-            data: "evil=<script>"
+            data: "evil=/bin/bash"
             version: HTTP/1.1
           output:
-            log_contains: id "941100"
+            log_contains: id "932160"
   - test_title: 9508119-2
     desc: Make sure iOS file upload workaround is disabled by default
     stages:
@@ -37,10 +37,10 @@ tests:
             port: 80
             method: PUT
             uri: /remote.php/dav/files/something
-            data: "evil=<script>"
+            data: "evil=/bin/bash"
             version: HTTP/1.1
           output:
-            log_contains: id "941100"
+            log_contains: id "932160"
   - test_title: 9508119-3
     desc: Make sure iOS file upload workaround is disabled by default
     stages:
@@ -55,10 +55,10 @@ tests:
             port: 80
             method: POST
             uri: /remote.php/dav/uploads/username/something
-            data: "evil=<script>"
+            data: "evil=/bin/bash"
             version: HTTP/1.1
           output:
-            log_contains: id "941100"
+            log_contains: id "932160"
   - test_title: 9508119-4
     desc: Make sure iOS file upload workaround is disabled by default
     stages:
@@ -73,10 +73,10 @@ tests:
             port: 80
             method: PUT
             uri: /remote.php/dav/uploads/username/something
-            data: "evil=<script>"
+            data: "evil=/bin/bash"
             version: HTTP/1.1
           output:
-            log_contains: id "941100"
+            log_contains: id "932160"
   - test_title: 9508119-5
     desc: Make sure iOS file upload workaround is disabled by default
     stages:
@@ -91,10 +91,10 @@ tests:
             port: 80
             method: POST
             uri: /remote.php/dav/uploads/username/something/something
-            data: "evil=<script>"
+            data: "evil=/bin/bash"
             version: HTTP/1.1
           output:
-            log_contains: id "941100"
+            log_contains: id "932160"
   - test_title: 9508119-6
     desc: Make sure iOS file upload workaround is disabled by default
     stages:
@@ -109,10 +109,10 @@ tests:
             port: 80
             method: PUT
             uri: /remote.php/dav/uploads/username/something/something
-            data: "evil=<script>"
+            data: "evil=/bin/bash"
             version: HTTP/1.1
           output:
-            log_contains: id "941100"
+            log_contains: id "932160"
   - test_title: 9508119-7
     desc: Make sure iOS file upload workaround is disabled by default
     stages:

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508119.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508119.yaml
@@ -1,0 +1,223 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+  enabled: true
+  name: 9508119.yaml
+tests:
+  - test_title: 9508119-1
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: POST
+            uri: /remote.php/dav/files/something
+            data: "evil=<script>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "941100"
+  - test_title: 9508119-2
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: PUT
+            uri: /remote.php/dav/files/something
+            data: "evil=<script>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "941100"
+  - test_title: 9508119-3
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: POST
+            uri: /remote.php/dav/uploads/username/something
+            data: "evil=<script>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "941100"
+  - test_title: 9508119-4
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: PUT
+            uri: /remote.php/dav/uploads/username/something
+            data: "evil=<script>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "941100"
+  - test_title: 9508119-5
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: POST
+            uri: /remote.php/dav/uploads/username/something/something
+            data: "evil=<script>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "941100"
+  - test_title: 9508119-6
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/x-www-form-urlencoded
+            port: 80
+            method: PUT
+            uri: /remote.php/dav/uploads/username/something/something
+            data: "evil=<script>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "941100"
+  - test_title: 9508119-7
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml
+            port: 80
+            method: POST
+            uri: /remote.php/dav/files/something
+            data: "<evil>/bin/bash</evil>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "932160"
+  - test_title: 9508119-8
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml
+            port: 80
+            method: PUT
+            uri: /remote.php/dav/files/something
+            data: "<evil>/bin/bash</evil>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "932160"
+  - test_title: 9508119-9
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml
+            port: 80
+            method: POST
+            uri: /remote.php/dav/uploads/username/something
+            data: "<evil>/bin/bash</evil>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "932160"
+  - test_title: 9508119-10
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml
+            port: 80
+            method: PUT
+            uri: /remote.php/dav/uploads/username/something
+            data: "<evil>/bin/bash</evil>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "932160"
+  - test_title: 9508119-11
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml
+            port: 80
+            method: POST
+            uri: /remote.php/dav/uploads/username/something/something
+            data: "<evil>/bin/bash</evil>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "932160"
+  - test_title: 9508119-12
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/6.2.4
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/xml
+            port: 80
+            method: PUT
+            uri: /remote.php/dav/uploads/username/something/something
+            data: "<evil>/bin/bash</evil>"
+            version: HTTP/1.1
+          output:
+            log_contains: id "932160"


### PR DESCRIPTION
This PR adds a workaround for the Nextcloud iOS app not setting the correct content type when uploading files making it impossible for CRS to parse it (Pretty much every single CRS rule is triggered). Since I've essentially disabled all rules for the request body (Excluding the `REQUEST_BODY` variable) I fear that this might cause something similar to [CVE-2021-35368](https://nvd.nist.gov/vuln/detail/CVE-2021-35368) so I've disabled the workaround by default but given an option to enable the workaround for those that need it. I've done what I could to minimize the risk/impact of a bypass for those that need this functionality, but I'm not fully satisfied with the solution.