### PR TITLE
fix: add workaround for libmodsecurity3 bug

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -897,6 +897,29 @@ SecRule REQUEST_FILENAME "@rx (?i)\.(?:avif|bmp|brotli|bvr|css|eot|gif|gz|ico|jp
     ver:'nextcloud-rule-exclusions-plugin/1.3.1',\
     ctl:ruleRemoveTargetById=932236;ARGS:v"
 
+# Setting SecRequestBodyNoFilesLimit to a very high value results in all requests
+# being interpreted as exceeding the configured limit due to a bug in libModSecurity3.
+# This rule is a workaround, it's possible this bug happens in other areas
+# but this has only been tested based on the recommendations in the plugin's readme.
+# See: https://github.com/owasp-modsecurity/ModSecurity/issues/3356
+SecRule REQUEST_FILENAME "@contains /remote.php/dav/files" \
+    "id:9508512,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.3.1',\
+    chain"
+    SecRule REQUEST_METHOD "@pm MKCOL DELETE" \
+        "t:none,\
+        chain"
+        SecRule REQUEST_HEADERS:Content-Type "@streq application/x-www-form-urlencoded" \
+            "t:none,\
+            chain"
+            SecRule REQUEST_HEADERS:content-length "@eq 0" \
+                "t:none,\
+                ctl:ruleRemoveById=200002"
+
 # Websocket connection to Files HBP (Notify_Push) don't have a user-agent.
 # Sometimes there will be a double slash after /push/
 SecRule REQUEST_FILENAME "@rx /push//?ws$" \

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -899,7 +899,7 @@ SecRule REQUEST_FILENAME "@rx (?i)\.(?:avif|bmp|brotli|bvr|css|eot|gif|gz|ico|jp
 
 # Setting SecRequestBodyNoFilesLimit to a very high value results in all requests
 # being interpreted as exceeding the configured limit due to a bug in libModSecurity3.
-# This rule is a workaround, it's possible this bug happens in other areas
+# This rule is a workaround for this bug. It's possible this bug happens in other areas
 # but this has only been tested based on the recommendations in the plugin's readme.
 # See: https://github.com/owasp-modsecurity/ModSecurity/issues/3356
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files" \

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -899,7 +899,7 @@ SecRule REQUEST_FILENAME "@rx (?i)\.(?:avif|bmp|brotli|bvr|css|eot|gif|gz|ico|jp
 
 # Setting SecRequestBodyNoFilesLimit to a very high value results in all requests
 # being interpreted as exceeding the configured limit due to a bug in libModSecurity3.
-# This rule is a workaround for this bug. It's possible this bug happens in other areas
+# This rule works around the bug for some common requests. It's possible this bug happens in other areas
 # but this has only been tested based on the recommendations in the plugin's readme.
 # See: https://github.com/owasp-modsecurity/ModSecurity/issues/3356
 SecRule REQUEST_FILENAME "@contains /remote.php/dav/files" \


### PR DESCRIPTION
Adds a workaround for https://github.com/owasp-modsecurity/ModSecurity/issues/3356 when setting `SecRequestBodyNoFilesLimit` to a high value for libModSecurity3 users. This workaround has only been tested against the configuration recommendations in the plugin readme.