### PR TITLE
chore: remove old rule exclusions

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -422,20 +422,8 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/comments/files(?:/[0-9]+)+$" \
     ctl:ruleRemoveTargetById=941160;XML"
 
 #
-# [ Searchengine ]
+# [ Search ]
 #
-
-# Nextcloud uses a search field for filename or content queries.
-SecRule REQUEST_FILENAME "@contains /index.php/core/search" \
-    "id:9508170,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveTargetById=941000-942999;ARGS:query,\
-    ctl:ruleRemoveTargetById=932000-932999;ARGS:query,\
-    ctl:ruleRemoveTargetByTag=attack-injection-php;ARGS:query"
 
 # Searching for files, folders, contacts, tasks, emails, etc.
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/search/providers(?:/[^/]+/search)?$" \
@@ -521,48 +509,11 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|public)\.php" \
         setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
 #
-# [ Preview and Thumbnails ]
-#
-
-# Preview
-SecRule REQUEST_FILENAME "@contains /index.php/core/preview.png" \
-    "id:9508210,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveTargetById=932150;ARGS:file"
-
-# Filepreview for trashbin
-SecRule REQUEST_FILENAME "@contains /index.php/apps/files_trashbin/ajax/preview.php" \
-    "id:9508211,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveTargetById=932150;ARGS:file,\
-    ctl:ruleRemoveTargetById=942190;ARGS:file"
-
-#
-# [ Ownnote ]
-#
-
-SecRule REQUEST_FILENAME "@contains /index.php/apps/ownnote/" \
-    "id:9508300,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveById=941150"
-
-#
 # [ Text Editor ]
 #
 
 # This file can save anything, and it's name could be lots of things.
+# Nextcloud 24 and older?
 SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
     "id:9508310,\
     phase:1,\
@@ -757,35 +708,6 @@ SecRule REQUEST_FILENAME "@rx /remote\.php/dav/calendars/(?:[^/]+/){2}[^/]+\.ics
     ctl:ruleRemoveById=920530"
 
 #
-# [ Notes ]
-#
-
-# We want to allow a lot of things as the user is
-# allowed to note on anything.
-SecRule REQUEST_FILENAME "@contains /index.php/apps/notes/" \
-    "id:9508350,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveByTag=attack-injection-php"
-
-#
-# [ Bookmarks ]
-#
-
-# Allow urls in data.
-SecRule REQUEST_FILENAME "@contains /index.php/apps/bookmarks/" \
-    "id:9508370,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveById=931130"
-
-#
 # [ Login forms and Logout ]
 #
 # This removes checks on the 'password' and related fields:
@@ -835,25 +757,7 @@ SecRule REQUEST_FILENAME "@rx /login/v[0-9.]+/grant$" \
     ctl:ruleRemoveTargetById=932236;ARGS:stateToken,\
     ctl:ruleRemoveTargetById=942450;ARGS:stateToken"
 
-# Reset password.
-SecRule REQUEST_FILENAME "@endsWith /login" \
-    "id:9508410,\
-    phase:2,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    chain"
-    SecRule ARGS:action "@streq resetpass" \
-        "t:none,\
-        chain"
-        SecRule &ARGS:action "@eq 1" \
-            "t:none,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass1-text,\
-            ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:pass2"
-
-# Password reset used in newer versions of Nextcloud
+# Resetting forgotten password
 SecRule REQUEST_FILENAME "@rx /lostpassword/set/[^/]+/[^/]+$" \
     "id:9508411,\
     phase:1,\
@@ -877,17 +781,6 @@ SecRule REQUEST_FILENAME "@endsWith /login/webauthn/finish" \
     SecRule RESPONSE_STATUS "@streq 500" \
         "t:none,\
         ctl:ruleRemoveById=950100"
-
-# Change Password and Setting up a new user/password
-SecRule REQUEST_FILENAME "@endsWith /settings/users" \
-    "id:9508500,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:newuserpassword,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
 # Nextcloud administrator setting/changing a user's password
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/cloud/users(?:/[^/]+)?$" \
@@ -1633,22 +1526,6 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/references/resolve(?:Public)?$"
     ctl:ruleRemoveTargetById=921151;ARGS_GET:reference,\
     ctl:ruleRemoveTargetById=920272;REQUEST_URI,\
     ctl:ruleRemoveTargetById=920272;REQUEST_URI_RAW"
-
-#
-# [ Extensions ]
-#
-
-# Extension: Ransomware protection
-
-# Allow configure file extensions fields
-SecRule REQUEST_FILENAME "@contains /config/apps/ransomware_protection/extension_additions" \
-    "id:9508900,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveTargetById=932130;ARGS:value"
 
 #
 # [ Nextcloud Notes ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -512,21 +512,6 @@ SecRule REQUEST_FILENAME "@rx /(?:remote|public)\.php" \
 # [ Text Editor ]
 #
 
-# This file can save anything, and it's name could be lots of things.
-# Nextcloud 24 and older?
-SecRule REQUEST_FILENAME "@contains /index.php/apps/files_texteditor/" \
-    "id:9508310,\
-    phase:1,\
-    pass,\
-    t:none,\
-    nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
-    ctl:ruleRemoveTargetById=920370-920390;ARGS:filecontents,\
-    ctl:ruleRemoveTargetById=920370-920390;ARGS_COMBINED_SIZE,\
-    ctl:ruleRemoveTargetById=921110-921160;ARGS:filecontents,\
-    ctl:ruleRemoveTargetById=932150;ARGS:filename,\
-    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:filecontents"
-
 # Handle false positives for token related false positives (Used for session
 # tracking, multi-user editing, guest edits, etc)
 # There are either way too many parameters that are used for specific endpoints or the


### PR DESCRIPTION
This PR removes rule exclusions for Nextcloud versions older than 24 and some EOL apps. 

Drops app support for:
Ransomware protection (No new release since 2022, does not support any actively maintained version of Nextcloud)
Ownnote (No commits since 2019)
Bookmarks (Support will be added back in a future PR with tests)