### PR TITLE
feat: add support for integrating external apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Additional apps may be supported if there is enough demand from the community, b
 | Nextcloud Files HPB (Notify_Push)   |  Supported ✅     |
 | Nextcloud News                      |  Supported ✅     |
 | Nextcloud Bookmarks                 |  Supported ✅     |
+| Nextcloud External                  |  Supported ✅     |
 | Nextcloud Talk                      |  Not supported ❌ |
 | Nextcloud Forms                     |  Not supported ❌ |
 | Nextcloud Polls                     |  Not supported ❌ |

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -572,8 +572,8 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]\.php/apps/external/api/v[0-9.]+/sites
     ctl:ruleRemoveTargetById=942432;ARGS:json.url,\
     ctl:ruleRemoveTargetById=920273;ARGS:url,\
     ctl:ruleRemoveTargetById=931130;ARGS:url,\
-    ctl:ruleRemoveTargetById=942432;ARGS:url"
-
+    ctl:ruleRemoveTargetById=942432;ARGS:url,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 #
 # [ Text Editor ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -556,6 +556,26 @@ SecRule REQUEST_FILENAME "@rx /index\.php/apps/bookmarks/public/rest/v[0-9.]+/bo
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 #
+# [ External Sites ]
+#
+
+# Adding/modifying a link to an external site
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]\.php/apps/external/api/v[0-9.]+/sites(?:/[0-9]+)?$" \
+    "id:9508240,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.4.0',\
+    ctl:ruleRemoveTargetById=920273;ARGS:json.url,\
+    ctl:ruleRemoveTargetById=931130;ARGS:json.url,\
+    ctl:ruleRemoveTargetById=942432;ARGS:json.url,\
+    ctl:ruleRemoveTargetById=920273;ARGS:url,\
+    ctl:ruleRemoveTargetById=931130;ARGS:url,\
+    ctl:ruleRemoveTargetById=942432;ARGS:url"
+
+
+#
 # [ Text Editor ]
 #
 

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508240.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508240.yaml
@@ -1,0 +1,46 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Bookmarks: External Sites"
+  enabled: true
+  name: 9508240.yaml
+tests:
+  - test_title: 9508240-1
+    desc: Adding an external link
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
+            port: 80
+            method: POST
+            uri: /ocs/v2.php/apps/external/api/v1/sites
+            data: |-
+              {"name":"test","url":"https://example.com","lang":"","type":"link","device":"","icon":"external.svg","groups":[],"redirect":0}
+            version: HTTP/1.1
+          output:
+            no_log_contains: |-
+              id "920273"|id "931130"|id "942432"
+  - test_title: 9508240-2
+    desc: Modifying an external link
+    stages:
+      - stage:
+          input:
+            dest_addr: 127.0.0.1
+            headers:
+              Host: localhost
+              User-Agent: OWASP CRS test agent
+              Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            port: 80
+            method: PUT
+            uri: /ocs/v2.php/apps/external/api/v1/sites/6
+            data |-
+              {"name":"test","url":"https://example.com","lang":"en","type":"link","device":"android","icon":"external.svg","groups":[],"redirect":1,"id":6}
+            version: HTTP/1.1
+          output:
+            no_log_contains: |-
+              id "920273"|id "931130"|id "942432"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508240.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508240.yaml
@@ -35,6 +35,7 @@ tests:
               Host: localhost
               User-Agent: OWASP CRS test agent
               Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+              Content-Type: application/json
             port: 80
             method: PUT
             uri: /ocs/v2.php/apps/external/api/v1/sites/6

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508240.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508240.yaml
@@ -38,7 +38,7 @@ tests:
             port: 80
             method: PUT
             uri: /ocs/v2.php/apps/external/api/v1/sites/6
-            data |-
+            data: |-
               {"name":"test","url":"https://example.com","lang":"en","type":"link","device":"android","icon":"external.svg","groups":[],"redirect":1,"id":6}
             version: HTTP/1.1
           output:


### PR DESCRIPTION
Adds support for the external app which allows the integration of non-nextcloud apps either via an iframe, a redirect, or a link in the login page.