### PR TITLE
fix: response rule exclusion disabling incorrect target

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1219,7 +1219,7 @@ SecRule REQUEST_FILENAME "@rx /browser(?:/[^/]+){3}\.json$" \
     chain"
     SecRule REQUEST_METHOD "@streq GET" \
         "t:none,\
-        ctl:ruleRemoveTargetById=953101;REQUEST_BODY"
+        ctl:ruleRemoveTargetById=953101;RESPONSE_BODY"
 
 #
 # [ Personal Settings ]


### PR DESCRIPTION
Excluded target for response rule was `REQUEST_BODY` instead of `RESPONSE_BODY`