### PR TITLE
refactor: remove the need of maintaining rule exclusion for server crawler outside of the plugin

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -16,6 +16,9 @@
 # Documentation can be found here:
 # https://github.com/coreruleset/nextcloud-rule-exclusions-plugin
 
+# Disable server crawler rule exclusions unless it's been enabled for a specific IP.
+SecRule &TX:nextcloud-rule-exclusions-plugin_server_crawler_rules_enabled "@eq 0" "id:9508097,phase:1,pass,nolog,ctl:ruleRemoveById=9508514"
+
 # Disable workaround for iOS file upload by default
 SecRule &TX:nextcloud-rule-exclusions-plugin_ios_workaround_enabled "@eq 0" "id:9508098,phase:1,pass,nolog,ctl:ruleRemoveById=9508119"
 
@@ -969,6 +972,25 @@ SecRule REQUEST_FILENAME "@rx /push//?ws$" \
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
     ctl:ruleRemoveById=920320"
+
+# Allow Nextcloud Server Crawler to crawl Nextcloud
+# Generating document previews with Collabora
+# Sometimes the server crawler's user agent will be missing/empty or an accept header is missing
+# TODO: Update readme to reflect changes before next plugin release
+SecRule REQUEST_FILENAME "@unconditionalMatch" \
+    "id:9508514,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ctl:ruleRemoveById=920300,\
+    ctl:ruleRemoveById=920320,\
+    ctl:ruleRemoveById=920330,\
+    ctl:ruleRemoveTargetById=920120;FILES:data,\
+    ctl:ruleRemoveTargetById=920121;FILES:data,\
+    ctl:ruleRemoveTargetById=920120;FILES_NAMES,\
+    ctl:ruleRemoveTargetById=920121;FILES_NAMES,\
+    ctl:ruleRemoveTargetById=922130;MULTIPART_PART_HEADERS"
 
 #
 # [ Nextcloud Setup ]

--- a/plugins/nextcloud-rule-exclusions-config.conf
+++ b/plugins/nextcloud-rule-exclusions-config.conf
@@ -56,3 +56,20 @@
 #     nolog,\
 #     ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
 #     setvar:'tx.nextcloud-rule-exclusions-plugin_ios_workaround_enabled=1'"
+
+# The Nextcloud Server Crawler is used by Nextcloud for various functions of
+# Nextcloud such as generating document previews with Collabora, and testing the 
+# functionality of Nextcloud (for example, when setting up the high performance backend for files).
+# Rule exclusions for the server crawler are disabled by default since we don't know the
+# IP address of your Nextcloud server in advance. To enable rule exclusions for the server crawler,
+# uncomment this rule and replace <your-server-ip> with your server's IP.
+# If you don't know what address to put here, it'll typically be one of two:
+#  1. Your server's WAN address
+#  2. If your server is behind a NAT firewall, it'll either be the private IP assigned via DHCP or the gateway IP for it's network
+# SecRule REMOTE_ADDR "@ipMatch <your-server-ip>" \
+#     "id:9508012,\
+#     phase:1,\
+#     pass,\
+#     nolog,\
+#     ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+#     setvar:'tx.nextcloud-rule-exclusions-plugin_server_crawler_rules_enabled=1'"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508514.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508514.yaml
@@ -1,0 +1,21 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+rule_id: 9508514
+tests:
+  - test_id: 1
+    desc: Make sure server crawler rule exclusions are disabled out of the box
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+          port: 80
+          method: GET
+          uri: /
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [920320]


### PR DESCRIPTION
Currently, false positives for the server crawler have to be resolved by copy-pasting an rule in the readme and kept in sync with any future plugin updates. This PR removes the need of maintaining a rule outside of the plugin which should simplify installation and maintenance for end users.

A new configuration variable has been created and if the IP address does not match the one configured in the SecRule, the variable will not be enabled and therefore will not enable the rule exclusions for the server crawler.

I haven't updated the readme to reflect this change (yet) to avoid confusing current users, I'll update it before a new plugin release which is when this change will be included.