### PR TITLE
feat: add support for nextcloud talk app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,36 +12,37 @@ Due to how feature rich Nextcloud is, not all apps in Nextcloud can be supported
 
 Additional apps may be supported if there is enough demand from the community, but in general, support for apps made by 3rd parties (not Nextcloud) won't be added.
 
-|             *App Name*              |      *Status*      |
-|------------------------------------ |--------------------|
-| Nextcloud Files                     |  Supported ✅     |
-| Nextcloud Photos                    |  Supported ✅     |
-| Nextcloud Calendar                  |  Supported ✅     |
-| Nextcloud Contacts                  |  Supported ✅     |
-| Nextcloud Teams (Formerly Circles)  |  Supported ✅     |
-| Nextcloud Mail                      |  Supported ✅     |
-| Nextcloud Deck                      |  Supported ✅     |
-| Nextcloud Office                    |  Supported ✅     |
-| Nextcloud Notes                     |  Supported ✅     |
-| Nextcloud Text Editor               |  Supported ✅     |
-| Nextcloud Recognize                 |  Supported ✅     |
-| Nextcloud Cookbook                  |  Supported ✅     |
-| Nextcloud Files HPB (Notify_Push)   |  Supported ✅     |
-| Nextcloud News                      |  Supported ✅     |
-| Nextcloud Bookmarks                 |  Supported ✅     |
-| Nextcloud External                  |  Supported ✅     |
-| Nextcloud Talk                      |  Not supported ❌ |
-| Nextcloud Forms                     |  Not supported ❌ |
-| Nextcloud Polls                     |  Not supported ❌ |
-| Nextcloud Unspash                   |  Not supported ❌ |
-| Nextcloud Collectives               |  Not supported ❌ |
-| Nextcloud Maps                      |  Not supported ❌ |
-| Cospend                             |  Not supported ❌ |
-| Breeze Dark                         |  Not supported ❌ |
-| OnlyOffice                          |  Not supported ❌ |
-| Nextcloud Tables                    |  Not supported ❌ |
-| Nextcloud Assistant                 |  Not supported ❌ |
-| ownCloud Music                      |  Not supported ❌ |
+|              *App Name*               |      *Status*      |
+|---------------------------------------|--------------------|
+| Nextcloud Files                       |  Supported ✅     |
+| Nextcloud Files HPB (Notify_Push)     |  Supported ✅     |
+| Nextcloud Photos                      |  Supported ✅     |
+| Nextcloud Calendar                    |  Supported ✅     |
+| Nextcloud Contacts                    |  Supported ✅     |
+| Nextcloud Teams (Formerly Circles)    |  Supported ✅     |
+| Nextcloud Mail                        |  Supported ✅     |
+| Nextcloud Deck                        |  Supported ✅     |
+| Nextcloud Office                      |  Supported ✅     |
+| Nextcloud Notes                       |  Supported ✅     |
+| Nextcloud Text Editor                 |  Supported ✅     |
+| Nextcloud Recognize                   |  Supported ✅     |
+| Nextcloud Cookbook                    |  Supported ✅     |
+| Nextcloud News                        |  Supported ✅     |
+| Nextcloud Bookmarks                   |  Supported ✅     |
+| Nextcloud External Apps               |  Supported ✅     |
+| Nextcloud Talk                        |  Supported ✅     |
+| Nextcloud Talk HPB (Signaling Server) |  Supported ✅     |
+| Nextcloud Forms                       |  Not supported ❌ |
+| Nextcloud Polls                       |  Not supported ❌ |
+| Nextcloud Unspash                     |  Not supported ❌ |
+| Nextcloud Collectives                 |  Not supported ❌ |
+| Nextcloud Maps                        |  Not supported ❌ |
+| Cospend                               |  Not supported ❌ |
+| Breeze Dark                           |  Not supported ❌ |
+| OnlyOffice                            |  Not supported ❌ |
+| Nextcloud Tables                      |  Not supported ❌ |
+| Nextcloud Assistant                   |  Not supported ❌ |
+| ownCloud Music                        |  Not supported ❌ |
 
 ## Tested Versions
 

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -380,9 +380,13 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/files_sharing/api/v[0-9.]+
     ctl:ruleRemoveTargetById=942432;ARGS:json.expireDate,\
     ctl:ruleRemoveTargetById=920273;ARGS:json.path,\
     ctl:ruleRemoveTargetById=930120;ARGS:json.path,\
+    ctl:ruleRemoveTargetById=942431;ARGS:json.path,\
+    ctl:ruleRemoveTargetById=942432;ARGS:json.path,\
     ctl:ruleRemoveTargetById=920273;ARGS:json.shareWith,\
     ctl:ruleRemoveTargetById=920273;ARGS:path,\
     ctl:ruleRemoveTargetById=930120;ARGS:path,\
+    ctl:ruleRemoveTargetById=942431;ARGS:path,\
+    ctl:ruleRemoveTargetById=942432;ARGS:path,\
     ctl:ruleRemoveTargetById=920273;ARGS:shareWith,\
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password,\
@@ -410,6 +414,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/files_sharing/api/v[0-9.]+
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
@@ -1694,7 +1699,6 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/room/[
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
 # Voice/Video calls via the built-in signaling server
-# TODO: Test screensharing
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/signaling/[^/]+$" \
     "id:9508752,\
     phase:1,\
@@ -1719,6 +1723,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/signal
     ctl:ruleRemoveTargetById=942432;ARGS:json.messages,\
     ctl:ruleRemoveTargetById=942460;ARGS:json.messages,\
     ctl:ruleRemoveTargetById=942520;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942550;ARGS:json.messages,\
     ctl:ruleRemoveTargetById=920273;ARGS:messages,\
     ctl:ruleRemoveTargetById=931130;ARGS:messages,\
     ctl:ruleRemoveTargetById=932200;ARGS:messages,\
@@ -1736,6 +1741,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/signal
     ctl:ruleRemoveTargetById=942432;ARGS:messages,\
     ctl:ruleRemoveTargetById=942460;ARGS:messages,\
     ctl:ruleRemoveTargetById=942520;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942550;ARGS:messages,\
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
 # Configuring Turn/High Performance backend server for Talk
@@ -1769,7 +1775,6 @@ SecRule REQUEST_FILENAME "@rx /call/[^/]+$" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
 
 # Sharing a voice recording, the message could be anything.
-# TODO: check if `ARGS:path` false positive are specific to Talk 
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/files_sharing/api/v[0-9.]+/shares$" \
     "id:9508755,\
     phase:1,\
@@ -1777,11 +1782,6 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/files_sharing/api/v[0-9.]+
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
-    ctl:ruleRemoveTargetById=942431;ARGS:json.path,\
-    ctl:ruleRemoveTargetById=942432;ARGS:json.path,\
-    ctl:ruleRemoveTargetById=942431;ARGS:path,\
-    ctl:ruleRemoveTargetById=942432;ARGS:path,\
-    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:talkMetaData,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.talkMetaData"
 

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1663,6 +1663,141 @@ SecRule REQUEST_FILENAME "@endsWith /apps/cookbook/webapp/import" \
     ctl:ruleRemoveTargetById=942432;ARGS:url"
 
 #
+# [ Nextcloud Talk ]
+#
+
+# Sending a message in a room
+# Message content could be anything
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/chat/[^/]+(?:/[0-9]+)?$" \
+    "id:9508750,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveTargetById=920273;ARGS:actorDisplayName,\
+    ctl:ruleRemoveTargetById=920273;ARGS:json.actorDisplayName,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.message"
+
+# Configuring a password for a room
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/room/[^/]+/password$" \
+    "id:9508751,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.password,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+
+# Voice/Video calls via the built-in signaling server
+# TODO: Test screensharing
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/signaling/[^/]+$" \
+    "id:9508752,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveTargetById=920273;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=931130;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=932200;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=932240;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=941120;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=941330;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=941340;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942200;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942300;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942330;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942340;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942370;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942430;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942431;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942432;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942460;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=942520;ARGS:json.messages,\
+    ctl:ruleRemoveTargetById=920273;ARGS:messages,\
+    ctl:ruleRemoveTargetById=931130;ARGS:messages,\
+    ctl:ruleRemoveTargetById=932200;ARGS:messages,\
+    ctl:ruleRemoveTargetById=932240;ARGS:messages,\
+    ctl:ruleRemoveTargetById=941120;ARGS:messages,\
+    ctl:ruleRemoveTargetById=941330;ARGS:messages,\
+    ctl:ruleRemoveTargetById=941340;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942200;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942300;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942330;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942340;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942370;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942430;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942431;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942432;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942460;ARGS:messages,\
+    ctl:ruleRemoveTargetById=942520;ARGS:messages,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
+
+# Configuring Turn/High Performance backend server for Talk
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/provisioning_api/api/v[0-9.]+/config/apps/spreed/(?:turn_servers|signaling_servers)$"\
+    "id:9508753,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveTargetById=920273;ARGS:value,\
+    ctl:ruleRemoveTargetById=932240;ARGS:value,\
+    ctl:ruleRemoveTargetById=942200;ARGS:value,\
+    ctl:ruleRemoveTargetById=942340;ARGS:value,\
+    ctl:ruleRemoveTargetById=942370;ARGS:value,\
+    ctl:ruleRemoveTargetById=942430;ARGS:value,\
+    ctl:ruleRemoveTargetById=942431;ARGS:value,\
+    ctl:ruleRemoveTargetById=942432;ARGS:value,\
+    ctl:ruleRemoveTargetById=942460;ARGS:value,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
+
+# Joining a public password protected call
+SecRule REQUEST_FILENAME "@rx /call/[^/]+$" \
+    "id:9508754,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:password"
+
+# Sharing a voice recording, the message could be anything.
+# TODO: check if `ARGS:path` false positive are specific to Talk 
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/files_sharing/api/v[0-9.]+/shares$" \
+    "id:9508755,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveTargetById=942431;ARGS:json.path,\
+    ctl:ruleRemoveTargetById=942432;ARGS:json.path,\
+    ctl:ruleRemoveTargetById=942431;ARGS:path,\
+    ctl:ruleRemoveTargetById=942432;ARGS:path,\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:talkMetaData,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.talkMetaData"
+
+# Creating a meeting for a room
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/room/[^/]+/meeting$" \
+    "id:9508756,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveTargetById=920273;REQUEST_BODY,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:description,\
+    ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.description"
+
+#
 # [ API ]
 #
 

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1686,8 +1686,9 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/chat/[
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.message"
 
-# Configuring a password for a room
-SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/room/[^/]+/password$" \
+# Configuring an password for an existing public room
+# Creating a password protected public room
+SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/room(?:/[^/]+/password)?$" \
     "id:9508751,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1708,7 +1708,7 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/chat/[
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:message,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.message"
 
-# Configuring an password for an existing public room
+# Configuring a password for an existing public room
 # Creating a password protected public room
 SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/spreed/api/v[0-9.]+/room(?:/[^/]+/password)?$" \
     "id:9508751,\

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508137.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508137.yaml
@@ -22,4 +22,6 @@ tests:
           version: HTTP/1.1
         output:
           log:
-            no_expect_ids: [941100]
+            no_expect_ids:
+              - 920273
+              - 941100

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508750.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508750.yaml
@@ -1,0 +1,47 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin: Nextcloud Talk"
+rule_id: 9508750
+tests:
+  - test_id: 1
+    desc: Sending a message in a room
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/json
+          port: 80
+          method: POST
+          uri: /ocs/v2.php/apps/spreed/api/v1/chat/roomid123
+          data: '{"message":"<script>","actorDisplayName":"Esad Cetiner","referenceId":"0123456789abcdef","silent":false}'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 941110
+  - test_id: 2
+    desc: Sending a message in a room
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/json
+          port: 80
+          method: PUT
+          uri: /ocs/v2.php/apps/spreed/api/v1/chat/roomid123/1
+          data: '{"message":"<script>alert"}'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 911100
+              - 920273
+              - 941110

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508751.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508751.yaml
@@ -1,0 +1,27 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin: Nextcloud Talk"
+rule_id: 9508751
+tests:
+  - test_id: 1
+    desc: Configuring a password for a room
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/json
+          port: 80
+          method: PUT
+          uri: /ocs/v2.php/apps/spreed/api/v4/room/roomid123/password
+          data: '{"password":"<script>"}'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 911100
+              - 920273
+              - 941110

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508751.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508751.yaml
@@ -5,7 +5,7 @@ meta:
 rule_id: 9508751
 tests:
   - test_id: 1
-    desc: Configuring a password for a room
+    desc: Configuring an password for an existing public room
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -23,5 +23,25 @@ tests:
           log:
             no_expect_ids:
               - 911100
+              - 920273
+              - 941110
+  - test_id: 2
+    desc: Creating a password protected public room
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/json
+          port: 80
+          method: POST
+          uri: /ocs/v2.php/apps/spreed/api/v4/room
+          data: '{"roomType":3,"roomName":"test","password":"<script>","description":"","listable":0,"participants":{}}'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
               - 920273
               - 941110

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508752.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508752.yaml
@@ -1,0 +1,44 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin: Nextcloud Talk"
+rule_id: 9508752
+tests:
+  - test_id: 1
+    desc: Participating in an voice/video call via the built-in signaling server
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/json
+          port: 80
+          method: POST
+          uri: /ocs/v2.php/apps/spreed/api/v3/signaling/roomid123
+          data: >-
+            {"messages":"[{\"ev\":\"message\",\"fn\":\"{\\\"to\\\":\\\"ic/random/random+random/random+random+random/random/IM/random\\\",
+            \\\"roomType\\\":\\\"video\\\",\\\"type\\\":\\\"nickChanged\\\",\\\"payload\\\":{\\\"name\\\":\\\"test\\\"}}\",
+            \"sessionId\":\"random+random+random+random/u+random+random/random/random\"}]"}
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 931130
+              - 932200
+              - 932240
+              - 941120
+              - 941330
+              - 941340
+              - 942200
+              - 942300
+              - 942330
+              - 942340
+              - 942370
+              - 942430
+              - 942431
+              - 942432
+              - 942460
+              - 942520

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508752.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508752.yaml
@@ -5,7 +5,7 @@ meta:
 rule_id: 9508752
 tests:
   - test_id: 1
-    desc: Participating in an voice/video call via the built-in signaling server
+    desc: Participating in a voice/video call via the built-in signaling server
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508753.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508753.yaml
@@ -1,0 +1,60 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin: Nextcloud Talk"
+rule_id: 9508753
+tests:
+  - test_id: 1
+    desc: Configuring an turnserver
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+          port: 80
+          method: POST
+          uri: /ocs/v2.php/apps/provisioning_api/api/v1/config/apps/spreed/turn_servers
+          data: 'value=%5B%7B%22schemes%22%3A%22turn%22%2C%22server%22%3A%22turn.example.com%22%2C%22secret%22%3A%22fd2ee1234567890abdefac4%22%2C%22protocols%22%3A%22udp%2Ctcp%22%7D%5D'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 932240
+              - 942200
+              - 942340
+              - 942370
+              - 942430
+              - 942431
+              - 942432
+              - 942460
+  - test_id: 2
+    desc: Configuring an signaling server (High Performance Backend)
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+          port: 80
+          method: POST
+          uri: /ocs/v2.php/apps/provisioning_api/api/v1/config/apps/spreed/signaling_servers
+          data: 'value=%7B%22servers%22%3A%5B%5D%2C%22secret%22%3A%22%22%7D'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 932240
+              - 942200
+              - 942340
+              - 942370
+              - 942430
+              - 942431
+              - 942432
+              - 942460

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508753.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508753.yaml
@@ -5,7 +5,7 @@ meta:
 rule_id: 9508753
 tests:
   - test_id: 1
-    desc: Configuring an turnserver
+    desc: Configuring an turn server
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508754.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508754.yaml
@@ -1,0 +1,26 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin: Nextcloud Talk"
+rule_id: 9508754
+tests:
+  - test_id: 1
+    desc: Joining a public password protected call
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/x-www-form-urlencoded; charset=UTF-8
+          port: 80
+          method: POST
+          uri: /call/id123
+          data: 'requesttoken=somethingcE7tM%3D%3AoTZrandom1R%2BSRtokenoJk%3D&password=%3CScript%3Eal3rt'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 941110

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508755.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508755.yaml
@@ -1,0 +1,28 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin: Nextcloud Talk"
+rule_id: 9508755
+tests:
+  - test_id: 1
+    desc: Sharing a voice recording
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/json
+          port: 80
+          method: POST
+          uri: /ocs/v2.php/apps/files_sharing/api/v1/shares
+          data: '{"shareType":10,"path":"/Talk/Talk recording from 2024-11-00 22-24-05 (Note to self).wav","shareWith":"123","referenceId":"1234567890abcdef","talkMetaData":"{\"messageType\":\"voice-message\",\"caption\":\"<script>\"}"}'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 941110
+              - 942431
+              - 942432

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508756.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508756.yaml
@@ -1,0 +1,26 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin: Nextcloud Talk"
+rule_id: 9508756
+tests:
+  - test_id: 1
+    desc: Creating a meeting for a room
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Host: localhost
+            User-Agent: OWASP CRS test agent
+            Accept: text/xml,application/xml,application/xhtml+xml,text/html;q=0.9,text/plain;q=0.8,image/png,*/*;q=0.5
+            Content-Type: application/json
+          port: 80
+          method: POST
+          uri: /ocs/v2.php/apps/spreed/api/v4/room/room123/meeting
+          data: '{"calendarUri":"personal-1","start":1748174400,"end":1748178000,"title":"test","description":"<script>","attendeeIds":null}'
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920273
+              - 941110


### PR DESCRIPTION
Adds support for the Nextcloud Talk app, a voice/video chat app with support for both with and without the high performance backend for Talk. All out of the box functionality in Nextcloud should now be fully covered by this plugin, along with a few popular official add-ons.