### PR TITLE
feat: add support for `enforce_bodyproc_urlencoded` config option

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1033,6 +1033,7 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
 
 # ModSecurity doesn't have a body parser that can correctly parse these Content Types without causing
 # very heavy false positives and pretty much disabling all rules.
+# TODO: Update readme to reflect support for `enforce_bodyproc_urlencoded`
 SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application/octet-stream|text/calendar|text/vcard)" \
     "id:9508515,\
     phase:1,\
@@ -1128,6 +1129,7 @@ SecRule REQUEST_FILENAME "@rx /(?:settings/admin/richdocuments|browser/[^/]+/adm
 # Checking document state with built in collabora CODE Server
 # ModSecurity doesn't have a body parser that can correctly parse text/plain Content Type without causing
 # very heavy false positives and pretty much disabling all rules.
+# TODO: Update readme to reflect support for `enforce_bodyproc_urlencoded`
 SecRule REQUEST_FILENAME "@endsWith /apps/richdocumentscode/proxy.php" \
     "id:9508540,\
     phase:1,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1034,7 +1034,7 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
 # ModSecurity doesn't have a body parser that can correctly parse these Content Types without causing
 # very heavy false positives and pretty much disabling all rules.
 # TODO: Update readme to reflect support for `enforce_bodyproc_urlencoded`
-SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application/octet-stream|text/calendar|text/vcard)" \
+SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application/octet-stream|text/calendar|text/vcard|image/)" \
     "id:9508515,\
     phase:1,\
     pass,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1031,6 +1031,17 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.update.properties.description,\
     ctl:ruleRemoveTargetByTag=OWASP_CRS;ARGS:json.message.data.chat.comment.message"
 
+# ModSecurity doesn't have a body parser that can correctly parse these Content Types without causing
+# very heavy false positives and pretty much disabling all rules.
+SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application/octet-stream|text/calendar|text/vcard)" \
+    "id:9508515,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.6.0',\
+    setvar:tx.enforce_bodyproc_urlencoded=0"
+
 #
 # [ Nextcloud Setup ]
 #
@@ -1110,13 +1121,13 @@ SecRule REQUEST_FILENAME "@rx /(?:settings/admin/richdocuments|browser/[^/]+/adm
     ctl:ruleRemoveTargetById=920273;ARGS:wopi_setting_base_url,\
     ctl:ruleRemoveTargetById=920273;REQUEST_BODY"
 
-
 #
 # [ Nextcloud Office - Built in Code Server ]
 #
 
 # Checking document state with built in collabora CODE Server
-# Text/plain content is not easily parseable by ModSecurity
+# ModSecurity doesn't have a body parser that can correctly parse text/plain Content Type without causing
+# very heavy false positives and pretty much disabling all rules.
 SecRule REQUEST_FILENAME "@endsWith /apps/richdocumentscode/proxy.php" \
     "id:9508540,\
     phase:1,\
@@ -1126,6 +1137,7 @@ SecRule REQUEST_FILENAME "@endsWith /apps/richdocumentscode/proxy.php" \
     ver:'nextcloud-rule-exclusions-plugin/1.6.0',\
     ctl:ruleRemoveTargetById=920273;ARGS:compat,\
     ctl:ruleRemoveTargetById=920273;ARGS:req,\
+    setvar:tx.enforce_bodyproc_urlencoded=0,\
     setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/plain|'"
 
 # Making changes to a document using built in collabora CODE Server


### PR DESCRIPTION
This PR adds support for users enabling the `enforce_bodyproc_urlencoded` option which closes a possible bypass of CRS by making sure a body parser is always activated.

There are a few cases where this behavior isn't desirable, this PR disables that config option in cases where it's not desirable.

I haven't updated the readme yet to avoid confusing existing users, I'll update it on the next release on the plugin.

I've been testing this for a few months so this should work fine.