### PR TITLE
Fix for iOS app setup

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -928,16 +928,7 @@ SecRule REQUEST_FILENAME "@rx /login/v[0-9]+(?:/poll)?$" \
     chain"
     SecRule REQUEST_HEADERS:User-Agent "@contains Nextcloud-iOS" \
         "t:none,\
-        chain"
-        SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
-            "t:none,\
-            chain"
-            SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
-                "t:none,\
-                chain"
-                SecRule REQUEST_METHOD "@streq POST" \
-                    "t:none,\
-                    ctl:ruleRemoveById=920180"
+        ctl:ruleRemoveById=920180"
 
 #
 # [ General rule exclusions ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -917,14 +917,14 @@ SecRule REQUEST_FILENAME "@rx /login(?:/selectchallenge|/challenge/[^/]+)?$" \
     ctl:ruleRemoveTargetById=942431;ARGS:redirect_url,\
     ctl:ruleRemoveTargetById=942432;ARGS:redirect_url"
 
-# During ios client configuration a POST request with insufficient content length will trigger mod_security
-SecRule REQUEST_FILENAME "@rx /login(/v2/poll)?" \
+# During initial iOS client configuration mod_security triggers "POST without Content-Length or Transfer-Encoding headers"
+SecRule REQUEST_FILENAME "@rx /login/v[0-9]+(?:/poll)?$" \
     "id:9508503,\
     phase:1,\
     pass,\
     t:none,\
     nolog,\
-    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ver:'nextcloud-rule-exclusions-plugin/1.6.0',\
     ctl:ruleRemoveById=920180"
 
 #

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -925,7 +925,19 @@ SecRule REQUEST_FILENAME "@rx /login/v[0-9]+(?:/poll)?$" \
     t:none,\
     nolog,\
     ver:'nextcloud-rule-exclusions-plugin/1.6.0',\
-    ctl:ruleRemoveById=920180"
+    chain"
+    SecRule REQUEST_HEADERS:User-Agent "@contains Nextcloud-iOS" \
+        "t:none,\
+        chain"
+        SecRule &REQUEST_HEADERS:Content-Length "@eq 0" \
+            "t:none,\
+            chain"
+            SecRule &REQUEST_HEADERS:Transfer-Encoding "@eq 0" \
+                "t:none,\
+                chain"
+                SecRule REQUEST_METHOD "@streq POST" \
+                    "t:none,\
+                    ctl:ruleRemoveById=920180"
 
 #
 # [ General rule exclusions ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -917,6 +917,15 @@ SecRule REQUEST_FILENAME "@rx /login(?:/selectchallenge|/challenge/[^/]+)?$" \
     ctl:ruleRemoveTargetById=942431;ARGS:redirect_url,\
     ctl:ruleRemoveTargetById=942432;ARGS:redirect_url"
 
+# During ios client configuration a POST request with insufficient content length will trigger mod_security
+SecRule REQUEST_FILENAME "@rx /login(/v2/poll)?" \
+    "id:9508503,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.5.0',\
+    ctl:ruleRemoveById=920180"
 
 #
 # [ General rule exclusions ]

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -917,7 +917,7 @@ SecRule REQUEST_FILENAME "@rx /login(?:/selectchallenge|/challenge/[^/]+)?$" \
     ctl:ruleRemoveTargetById=942431;ARGS:redirect_url,\
     ctl:ruleRemoveTargetById=942432;ARGS:redirect_url"
 
-# During initial iOS app configuration mod_security triggers "POST without Content-Length or Transfer-Encoding headers"
+# During initial iOS client configuration mod_security triggers "POST without Content-Length or Transfer-Encoding headers"
 SecRule REQUEST_FILENAME "@rx /login/v[0-9]+(?:/poll)?$" \
     "id:9508503,\
     phase:1,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -917,7 +917,7 @@ SecRule REQUEST_FILENAME "@rx /login(?:/selectchallenge|/challenge/[^/]+)?$" \
     ctl:ruleRemoveTargetById=942431;ARGS:redirect_url,\
     ctl:ruleRemoveTargetById=942432;ARGS:redirect_url"
 
-# During initial iOS client configuration mod_security triggers "POST without Content-Length or Transfer-Encoding headers"
+# During initial iOS app configuration mod_security triggers "POST without Content-Length or Transfer-Encoding headers"
 SecRule REQUEST_FILENAME "@rx /login/v[0-9]+(?:/poll)?$" \
     "id:9508503,\
     phase:1,\

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
@@ -15,7 +15,7 @@ tests:
           headers:
             Host: localhost
             User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/33.0.7
-            Accept: Accept: */*
+            Accept: */*
             Content-Length: 0
           port: 80
           method: POST
@@ -23,5 +23,4 @@ tests:
         version: HTTP/1.1
         output:
           log:
-            no_expect_ids:
-              - 920180
+            no_expect_ids: [920180]

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
@@ -20,7 +20,7 @@ tests:
           port: 80
           method: POST
           uri: /index.php/login/v2/poll?token=mL9ackQ9Kv4n03OoUsT048ctWE0Fn6LGm7POWx2Fh8wn1TfnjZPS6MqqpKYoLW3aSxv6nHqM63wItq123mtepcTt0K8rJLIFL67M5GKaabblInw321zbBLh2fQKQm0Ac
-        version: HTTP/1.1
+          version: HTTP/1.1
         output:
           log:
             no_expect_ids: [920180]

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
@@ -1,0 +1,27 @@
+---
+meta:
+  author: "Matthieu Schapranow"
+  description: "Nextcloud Rule Exclusions Plugin: Setup iOS app polling authentication"
+rule_id: 9508503
+tests:
+  - test_id: 1
+    desc: |
+      iOS app authentication flow using polling during initial setup
+      This POST request is sent without content-length and a random polling token
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          autocomplete_headers: false
+          headers:
+            Host: localhost
+            User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/33.0.7
+            Accept: Accept: */*
+            Content-Length: 0
+          port: 80
+          method: POST
+          uri: /index.php/login/v2/poll?token=mL9ackQ9Kv4n03OoUsT048ctWE0Fn6LGm7POWx2Fh8wn1TfnjZPS6MqqpKYoLW3aSxv6nHqM63wItq123mtepcTt0K8rJLIFL67M5GKaabblInw321zbBLh2fQKQm0Ac
+        version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920180

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
@@ -7,7 +7,7 @@ tests:
   - test_id: 1
     desc: |
       iOS app authentication flow using polling during initial setup
-      This POST request is sent without content-length and a random polling token
+      This POST request is sent w/o content-length and a random polling token
     stages:
       - input:
           dest_addr: 127.0.0.1
@@ -15,7 +15,7 @@ tests:
           headers:
             Host: localhost
             User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/33.0.7
-            Accept: */*
+            Accept: "*/*"
             Content-Length: 0
           port: 80
           method: POST


### PR DESCRIPTION
New PR using signed commits of rule `9508503` for fixing iOS app polling triggering rule `920180` (in response to #152, which was unable to merge due to unsigned commits).