### PR TITLE
Fix ios setup

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -917,6 +917,18 @@ SecRule REQUEST_FILENAME "@rx /login(?:/selectchallenge|/challenge/[^/]+)?$" \
     ctl:ruleRemoveTargetById=942431;ARGS:redirect_url,\
     ctl:ruleRemoveTargetById=942432;ARGS:redirect_url"
 
+# During initial iOS client configuration mod_security triggers "POST without Content-Length or Transfer-Encoding headers"
+SecRule REQUEST_FILENAME "@rx /login/v[0-9]+(?:/poll)?$" \
+    "id:9508503,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.6.0',\
+    chain"
+    SecRule REQUEST_HEADERS:User-Agent "@contains Nextcloud-iOS" \
+        "t:none,\
+        ctl:ruleRemoveById=920180"
 
 #
 # [ General rule exclusions ]

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508503.yaml
@@ -1,0 +1,26 @@
+---
+meta:
+  author: "Matthieu Schapranow"
+  description: "Nextcloud Rule Exclusions Plugin: Setup iOS app polling authentication"
+rule_id: 9508503
+tests:
+  - test_id: 1
+    desc: |
+      iOS app authentication flow using polling during initial setup
+      This POST request is sent w/o content-length and a random polling token
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          autocomplete_headers: false
+          headers:
+            Host: localhost
+            User-Agent: Mozilla/5.0 (iOS) Nextcloud-iOS/33.0.7
+            Accept: "*/*"
+            Content-Length: 0
+          port: 80
+          method: POST
+          uri: /index.php/login/v2/poll?token=mL9ackQ9Kv4n03OoUsT048ctWE0Fn6LGm7POWx2Fh8wn1TfnjZPS6MqqpKYoLW3aSxv6nHqM63wItq123mtepcTt0K8rJLIFL67M5GKaabblInw321zbBLh2fQKQm0Ac
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids: [920180]


### PR DESCRIPTION
Added rule 9508503 to handle iOS client polling during setup triggering 920180. Follow up to #152 and #153 using unsigned commits blocking merge. 