### PR TITLE
fix(files): locking a file when editing it locally via dav client

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -280,6 +280,22 @@ SecRule REQUEST_FILENAME "@rx /ocs/v[0-9.]+\.php/apps/recommendations/api/v[0-9.
             "t:none,\
             ctl:ruleRemoveById=200002"
 
+# PUT /remote.php/dav/files/esadc/test.odt HTTP/1.1
+# Dav clients locking an office document when editing on a local machine.
+# Nextcloud 34 and newer
+SecRule REQUEST_FILENAME "@contains /remote.php/dav/files/" \
+    "id:9508121,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.6.0',\
+    chain"
+    SecRule &REQUEST_HEADERS:If "@eq 1" \
+        "t:none,\
+        ctl:ruleRemoveById=920450,\
+        ctl:ruleRemoveTargetById=920274;REQUEST_HEADERS:If"
+
 #
 # [ File Manager - Web GUI ]
 #

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508121.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508121.yaml
@@ -10,7 +10,7 @@ tests:
       - input:
           dest_addr: 127.0.0.1
           headers:
-            Accept: */*
+            Accept: "*/*"
             X-Oc-Mtime: 1785031392
             Oc-Total-Length: 9332
             If-Match: "6a656ad1001ba"

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508121.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508121.yaml
@@ -1,11 +1,10 @@
 ---
 meta:
   author: "Esad Cetiner"
-  description: "Nextcloud Rule Exclusions Plugin"
+  description: "Nextcloud Rule Exclusions Plugin: Dav client locking a file"
 rule_id: 9508121
 tests:
   - test_id: 1
-    desc: Make sure iOS file upload workaround is disabled by default
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508121.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508121.yaml
@@ -1,0 +1,37 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Rule Exclusions Plugin"
+rule_id: 9508121
+tests:
+  - test_id: 1
+    desc: Make sure iOS file upload workaround is disabled by default
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            Accept: */*
+            X-Oc-Mtime: 1785031392
+            Oc-Total-Length: 9332
+            If-Match: "6a656ad1001ba"
+            User-Agent: "Mozilla/5.0 (Windows) mirall/33.0.7 (build 20260629) (Nextcloud, windows-10.0.26200 ClientArchitecture: x86_64 OsArchitecture: x86_64)"
+            If: <https://example.com/remote.php/dav/files/esadc/test.odt> (<opaquelocktoken:files_lock/ae11a9f4-647b-4686-aa22-a38bc6c57358>)
+            Oc-Chunk-Size: 104857600
+            Content-Type: application/octet-stream
+            Oc-Checksum: SHA1:9bcc49f899d6c97d9dadbf484ee5fe4f5b6b2f41
+            Host: localhost
+            X-Request-Id: 14a16b47-73eb-4ed0-9999-da177733dfcc
+            Content-Length: 9332
+            Accept-Encoding: zstd, br, gzip, deflate
+            Connection: Keep-Alive
+            Accept-Language: en-AU,*
+          port: 80
+          method: PUT
+          uri: /remote.php/dav/files/esadc/test.odt
+          data: "file goes here"
+          version: HTTP/1.1
+        output:
+          log:
+            no_expect_ids:
+              - 920274
+              - 920450

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508121.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508121.yaml
@@ -21,9 +21,7 @@ tests:
             Oc-Checksum: SHA1:9bcc49f899d6c97d9dadbf484ee5fe4f5b6b2f41
             Host: localhost
             X-Request-Id: 14a16b47-73eb-4ed0-9999-da177733dfcc
-            Content-Length: 9332
             Accept-Encoding: zstd, br, gzip, deflate
-            Connection: Keep-Alive
             Accept-Language: en-AU,*
           port: 80
           method: PUT


### PR DESCRIPTION
In Nextcloud 34 and newer, a new feature was introduced where when editing a document locally, the local dav client will lock the file to prevent any modifications to that file. The locking request contains an `if` header which trips CRS's restricted headers rule.

closes: https://github.com/coreruleset/nextcloud-rule-exclusions-plugin/issues/156