### PR TITLE
fix(body-processor): multiple false positives with forcing request body processor

### DIFF
--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -1006,7 +1006,7 @@ SecRule REQUEST_FILENAME "@rx /push//?ws$" \
 # Sometimes the server crawler's user agent will be missing/empty or an accept header is missing
 # Nextcloud sends Talk messages to signalling server when configured on NC 33 and newer.
 # TODO: This rule contains rule-exclusions for Collabora Server, Nextcloud Server Crawler, and Signaling server all in one.
-# it needs to be split into different rules to better accomidate distributed setups. 
+# it needs to be split into different rules to better accomidate distributed setups.
 SecRule REQUEST_FILENAME "@unconditionalMatch" \
     "id:9508514,\
     phase:1,\

--- a/plugins/nextcloud-rule-exclusions-before.conf
+++ b/plugins/nextcloud-rule-exclusions-before.conf
@@ -17,7 +17,7 @@
 # https://github.com/coreruleset/nextcloud-rule-exclusions-plugin
 
 # Disable server crawler rule exclusions unless it's been enabled for a specific IP.
-SecRule &TX:nextcloud-rule-exclusions-plugin_server_crawler_rules_enabled "@eq 0" "id:9508097,phase:1,pass,nolog,ctl:ruleRemoveById=9508514"
+SecRule &TX:nextcloud-rule-exclusions-plugin_server_crawler_rules_enabled "@eq 0" "id:9508097,phase:1,pass,nolog,ctl:ruleRemoveById=9508514,ctl:ruleRemoveById=9508557,ctl:ruleRemoveById=9508558"
 
 # Disable workaround for iOS file upload by default
 SecRule &TX:nextcloud-rule-exclusions-plugin_ios_workaround_enabled "@eq 0" "id:9508098,phase:1,pass,nolog,ctl:ruleRemoveById=9508119"
@@ -180,7 +180,8 @@ SecRule REQUEST_FILENAME "@rx /(?:remote\.php/(?:dav/bulk$|dav/files/|dav/upload
         ctl:ruleRemoveTargetById=944210;REQUEST_BODY,\
         ctl:ruleRemoveTargetById=944240;REQUEST_BODY,\
         ctl:ruleRemoveTargetById=944250;REQUEST_BODY,\
-        ctl:ruleRemoveTargetById=944260;REQUEST_BODY"
+        ctl:ruleRemoveTargetById=944260;REQUEST_BODY,\
+        setvar:tx.enforce_bodyproc_urlencoded=0"
 
 # Syncing files with Nextcloud desktop app
 # Matches:
@@ -1004,6 +1005,8 @@ SecRule REQUEST_FILENAME "@rx /push//?ws$" \
 # Generating document previews with Collabora
 # Sometimes the server crawler's user agent will be missing/empty or an accept header is missing
 # Nextcloud sends Talk messages to signalling server when configured on NC 33 and newer.
+# TODO: This rule contains rule-exclusions for Collabora Server, Nextcloud Server Crawler, and Signaling server all in one.
+# it needs to be split into different rules to better accomidate distributed setups. 
 SecRule REQUEST_FILENAME "@unconditionalMatch" \
     "id:9508514,\
     phase:1,\
@@ -1046,7 +1049,7 @@ SecRule REQUEST_FILENAME "@unconditionalMatch" \
 # ModSecurity doesn't have a body parser that can correctly parse these Content Types without causing
 # very heavy false positives and pretty much disabling all rules.
 # TODO: Update readme to reflect support for `enforce_bodyproc_urlencoded`
-SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application/octet-stream|text/calendar|text/vcard|image/)" \
+SecRule REQUEST_HEADERS:Content-Type "@rx ^(?:application/octet-stream|text/calendar|text/vcard)" \
     "id:9508515,\
     phase:1,\
     pass,\
@@ -1323,6 +1326,40 @@ SecRule REQUEST_FILENAME "@contains /cool/https://" \
         "t:none,\
         t:urlDecode,\
         ctl:ruleRemoveTargetById=931131;REQUEST_FILENAME"
+
+# Removing a word from dictionary
+SecRule REQUEST_HEADERS:User-Agent "@beginsWith COOLWSD HTTP Agent" \
+    "id:9508557,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.6.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@endsWith /apps/richdocuments/wopi/settings/upload" \
+        "t:none,\
+        chain"
+        SecRule REQUEST_HEADERS:Content-Type "@beginsWith text/html" \
+            "t:none,\
+            setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |text/html|',\
+            setvar:tx.enforce_bodyproc_urlencoded=0"
+
+# Adding a word to dictionary
+SecRule REQUEST_HEADERS:User-Agent "@beginsWith COOLWSD HTTP Agent" \
+    "id:9508558,\
+    phase:1,\
+    pass,\
+    t:none,\
+    nolog,\
+    ver:'nextcloud-rule-exclusions-plugin/1.6.0',\
+    chain"
+    SecRule REQUEST_FILENAME "@endsWith /index.php/apps/richdocuments/wopi/settings/upload" \
+        "t:none,\
+        chain"
+        SecRule REQUEST_HEADERS:Content-Type "@beginsWith application/octet-stream" \
+            "t:none,\
+            setvar:'tx.allowed_request_content_type=%{tx.allowed_request_content_type} |application/octet-stream|',\
+            setvar:tx.enforce_bodyproc_urlencoded=0"
 
 #
 # [ Personal Settings ]

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508557.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508557.yaml
@@ -5,6 +5,7 @@ meta:
 rule_id: 9508557
 tests:
   - test_id: 1
+    desc: Ensure rule-exclusion is disabled by default
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508557.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508557.yaml
@@ -1,0 +1,32 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Office: Removing a word from dictionary"
+rule_id: 9508557
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            User-Agent: COOLWSD HTTP Agent 25.04.11.3
+            Date: Sun, 28 Jun 2026 05:25:35
+            Authorization: Bearer aaaa123
+            Host: cloud.example.com
+            X-WOPI-TimeStamp: 639182211358086135
+            X-WOPI-Proof: a+a+a/ZrB5Xez/H/G8E/iArbKyO+a/a+a+Ufyg==
+            X-WOPI-ProofOld: a+a+a/a/H/G8E/a+a/a+a+Ufyg==
+            X-COOL-WOPI-ServerId: abcdef1234
+            Content-Type: text/html
+          port: 80
+          method: POST
+          uri: /apps/richdocuments/wopi/settings/upload?fileId=%2Fsettings%2Fuserconfig%2Fwordbook%2Fstandard.dic&access_token=aaaa
+          data: |-
+            OOoUserDict1
+            lang: <none>
+            type: positive
+            ---
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [920420]

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508558.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508558.yaml
@@ -5,6 +5,7 @@ meta:
 rule_id: 9508558
 tests:
   - test_id: 1
+    desc: Ensure rule-exclusion is disabled by default
     stages:
       - input:
           dest_addr: 127.0.0.1

--- a/tests/regression/nextcloud-rule-exclusions-plugin/9508558.yaml
+++ b/tests/regression/nextcloud-rule-exclusions-plugin/9508558.yaml
@@ -1,0 +1,35 @@
+---
+meta:
+  author: "Esad Cetiner"
+  description: "Nextcloud Office: Adding a word to dictionary"
+rule_id: 9508558
+tests:
+  - test_id: 1
+    stages:
+      - input:
+          dest_addr: 127.0.0.1
+          headers:
+            User-Agent: COOLWSD HTTP Agent 25.04.11.3
+            Date: Sun, 28 Jun 2026 05:25:35
+            Authorization: Bearer aaaa123
+            Host: cloud.example.com
+            X-WOPI-TimeStamp: 639182211358086135
+            Content-Length: 52
+            X-WOPI-Proof: a+a+a/ZrB5Xez/H/G8E/iArbKyO+a/a+a+Ufyg==
+            X-WOPI-ProofOld: a+a+a/a/H/G8E/a+a/a+a+Ufyg==
+            X-COOL-WOPI-ServerId: abcdef1234
+            Content-Type: application/octet-stream
+          port: 80
+          method: POST
+          uri: /index.php/apps/richdocuments/wopi/settings/upload?access_token=aaaa123&access_token_ttl=0&fileId=%2Fsettings%2Fuserconfig%2Fwordbook%2Fstandard.dic
+          data: |-
+            BEGINBODY
+            OOoUserDict1
+            lang: <none>
+            type: positive
+            ---
+            sdfsad
+          version: HTTP/1.1
+        output:
+          log:
+            expect_ids: [920420]


### PR DESCRIPTION
Fixes false positives when forcing a body processor with `enforce_bodyproc_urlencoded` option relating to file upload and the collabora office document server.